### PR TITLE
Add -std=legacy gfortran flag to compile code using gcc 8.1.

### DIFF
--- a/Code/CMake/SimVascularOptions.cmake
+++ b/Code/CMake/SimVascularOptions.cmake
@@ -109,8 +109,15 @@ mark_as_advanced(SV_USE_WIN32_REGISTRY)
 #-----------------------------------------------------------------------------
 # Enable Fortran
 enable_language(Fortran)
+get_filename_component(Fortran_COMPILER_NAME ${CMAKE_Fortran_COMPILER} NAME)
 if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU")
   set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -ffixed-line-length-132 -cpp")
+  simvascular_get_major_minor_version(${CMAKE_Fortran_COMPILER_VERSION} COMPILER_MAJOR_VERSION 
+    COMPILER_MINOR_VERSION)
+  # Set the -std=legacy option to compile code using gcc 8.1 (see svSolver GitHub Issue #32). 
+  if(APPLE AND (Fortran_COMPILER_NAME MATCHES "gfortran.*") AND (COMPILER_MAJOR_VERSION EQUAL 8))
+      set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -std=legacy")
+  endif()
 else()
   set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -132 -fpp")
 endif()

--- a/Code/CMake/SimVascularSystemSetup.cmake
+++ b/Code/CMake/SimVascularSystemSetup.cmake
@@ -172,7 +172,7 @@ elseif(LINUX)
     OUTPUT_STRIP_TRAILING_WHITESPACE)
 
   # Get distribution name and version number from lsb_release output
-  STRING(REGEX REPLACE "Distributor ID:[\t]*([^ \n\r]+).*$" "\\1" LSB_DISTRIB "${LSB_RELEASE_INFO}")
+  STRING(REGEX REPLACE "^.*Distributor ID:[\t]*([^ \n\r]+).*$" "\\1" LSB_DISTRIB "${LSB_RELEASE_INFO}")
   STRING(REGEX REPLACE "^.*Release:[\t]*([^ \n\r]+).*$" "\\1" LSB_VERSION "${LSB_RELEASE_INFO}")
   string(TOLOWER "${LSB_DISTRIB}" _platform_lower)
 


### PR DESCRIPTION
The solver was not compiling on OSX with gcc 8.1. See GitHub Issue #32.