### PR TITLE
External tissue support

### DIFF
--- a/Code/FlowSolvers/ThreeDSolver/SolverIO/cvSolverIO.cxx
+++ b/Code/FlowSolvers/ThreeDSolver/SolverIO/cvSolverIO.cxx
@@ -260,11 +260,11 @@ int cvsolverIO::readDataBlock ( const char* keyphrase,
     }
 
     // error check..
-    // since we require that a consistant header always preceed the data block
+    // since we require that a consistent header always precede the data block
     // let us check to see that it is actually the case.    
 
     if ( ! cscompare( LastHeaderKey_, keyphrase ) ) {
-        fprintf(stderr,"ERROR: header not consistant with data block\n");
+        fprintf(stderr,"ERROR: header not consistent with data block\n");
         fprintf(stderr,"Header: %s\n", LastHeaderKey_);
         fprintf(stderr,"DataBlock: %s\n", keyphrase);
         fprintf(stderr,"Please recheck read sequence\n");
@@ -418,11 +418,11 @@ int cvsolverIO::writeDataBlock (const char* keyphrase,
     }
 
     // error check..
-    // since we require that a consistant header always preceed the data block
+    // since we require that a consistent header always precede the data block
     // let us check to see that it is actually the case.    
 
     if ( ! cscompare( LastHeaderKey_, keyphrase ) ) {
-        fprintf(stderr,"ERROR: header not consistant with data block\n");
+        fprintf(stderr,"ERROR: header not consistent with data block\n");
         fprintf(stderr,"Header: %s\n", LastHeaderKey_);
         fprintf(stderr,"DataBlock: %s\n", keyphrase);
         fprintf(stderr,"Please recheck read sequence\n");

--- a/Code/FlowSolvers/ThreeDSolver/svPre/cmd.cxx
+++ b/Code/FlowSolvers/ThreeDSolver/svPre/cmd.cxx
@@ -76,6 +76,13 @@ static Cmd cmd_table[] = {
 #if(VER_VARWALL == 1)
   {"set_surface_thickness", cmd_set_thickness_BCs},
   {"set_surface_Evw", cmd_set_Evw_BCs},
+
+  /********* EXTERNAL TISSUE SUPPORT ISL JULY 2019 *******************/
+  {"set_surface_ks", cmd_set_ksvw_BCs},
+  {"set_surface_cs", cmd_set_csvw_BCs},
+  {"set_surface_p0", cmd_set_p0vw_BCs},
+  /*********************************************************************/
+
   {"set_surface_initial_Evw", cmd_set_Initial_Evw},
   {"varwallprop_write_vtk", cmd_varwallprop_write_vtk},
 #endif
@@ -117,9 +124,23 @@ static Cmd cmd_table[] = {
   {"read_varwallprop_geombc",cmd_read_geombc_varwallprop},
   {"set_surface_thickness_vtp", cmd_set_thickness_BCs_vtp},
   {"set_surface_E_vtp", cmd_set_Evw_BCs_vtp},
+
+  /********* EXTERNAL TISSUE SUPPORT ISL JULY 2019 *******************/
+  {"set_surface_ks_vtp", cmd_set_ksvw_BCs_vtp},
+  {"set_surface_cs_vtp", cmd_set_csvw_BCs_vtp},
+  {"set_surface_p0_vtp", cmd_set_p0vw_BCs_vtp},
+/*********************************************************************/
+
   {"set_surface_initial_E_vtp", cmd_set_Initial_Evw_vtp},
   {"solve_varwall_thickness",cmd_Laplace_Thickness},
   {"solve_varwall_E",cmd_Laplace_Evw},
+
+  /********* EXTERNAL TISSUE SUPPORT ISL JULY 2019 *******************/
+  {"solve_varwall_ks", cmd_Laplace_Ksvw},
+  {"solve_varwall_cs", cmd_Laplace_Csvw},
+  {"solve_varwall_p0", cmd_Laplace_P0vw},
+  /*********************************************************************/
+
   {"solve_transient_varwall_E",cmd_Transient_Laplace_Evw},
   {"deformable_solve_varwall_displacements", cmd_deformable_iterative_solve_var_prop},
   {"varwallprop_write_vtp", cmd_varwallprop_write_vtp},

--- a/Code/FlowSolvers/ThreeDSolver/svPre/cmd.h
+++ b/Code/FlowSolvers/ThreeDSolver/svPre/cmd.h
@@ -94,10 +94,7 @@ extern "C" {
 }
 
 // actual commands
-
-//
 // can use VTU to replace all of these calls
-//
 int CALLTYPE cmd_number_of_nodes(char*);
 int CALLTYPE cmd_number_of_elements(char*);
 int CALLTYPE cmd_number_of_mesh_edges(char*);
@@ -205,12 +202,29 @@ int CALLTYPE cmd_append_displacements(char*);
 #if(VER_VARWALL == 1)
 int CALLTYPE cmd_Laplace_Thickness(char*);
 int CALLTYPE cmd_Laplace_Evw(char*);
+
+/*** EXTERNAL TISSUE SUPPORT - ISL July 2019 ***/
+int CALLTYPE cmd_Laplace_Ksvw(char*);
+int CALLTYPE cmd_Laplace_Csvw(char*);
+int CALLTYPE cmd_Laplace_P0vw(char*);
+/***********************************************/
+
 int CALLTYPE cmd_Transient_Laplace_Evw(char*);
 int CALLTYPE cmd_set_scalar_BCs(char*);
 int CALLTYPE cmd_set_thickness_BCs(char*);
 int CALLTYPE cmd_set_thickness_BCs_vtp(char*);
 int CALLTYPE cmd_set_Evw_BCs(char*);
 int CALLTYPE cmd_set_Evw_BCs_vtp(char*);
+
+/*** EXTERNAL TISSUE SUPPORT - ISL July 2019 ***/
+int CALLTYPE cmd_set_ksvw_BCs(char*);
+int CALLTYPE cmd_set_ksvw_BCs_vtp(char*);
+int CALLTYPE cmd_set_csvw_BCs(char*);
+int CALLTYPE cmd_set_csvw_BCs_vtp(char*);
+int CALLTYPE cmd_set_p0vw_BCs(char*);
+int CALLTYPE cmd_set_p0vw_BCs_vtp(char*);
+/***********************************************/
+
 int CALLTYPE cmd_set_Initial_Evw(char*);
 int CALLTYPE cmd_set_Initial_Evw_vtp(char*);
 int CALLTYPE cmd_varwallprop_write_vtp(char*);

--- a/Code/FlowSolvers/ThreeDSolver/svPre/presolver-vtk-cmds.cxx
+++ b/Code/FlowSolvers/ThreeDSolver/svPre/presolver-vtk-cmds.cxx
@@ -101,7 +101,7 @@ extern double* EvwSolution_;
 extern double* KsvwSolution_;
 extern double* CsvwSolution_;
 extern double* P0vwSolution_;
-
+extern int itissuesuppt;
 #endif
 
 int writeGEOMBCDAT(char* filename);
@@ -114,7 +114,7 @@ int NWgetNextNonBlankLine(int *eof);
 int NWcloseFile();
 int setNodesWithCode(char *cmd, int val);
 int setBoundaryFacesWithCode(char *cmd, int setSurfID, int surfID, int setCode,
-		int code, double value);
+        int code, double value);
 int parseDouble(char *cmd, double *num);
 int parseDouble2(char *cmd, double *num);
 int parseDouble3(char *cmd, double *v1, double *v2, double *v3);
@@ -122,7 +122,7 @@ int parseCmdStr(char *cmd, char *mystr);
 int parseCmdStr2(char *cmd, char *mystr);
 int parseNum2(char *cmd, int *num);
 int check_node_order(int n0, int n1, int n2, int n3, int elementId, int *k0,
-		int *k1, int *k2, int *k3);
+        int *k1, int *k2, int *k3);
 //int fixFreeEdgeNodes(char *cmd);
 void siftDownEdges(int **edges, int root, int bottom, int array_size);
 //int createMeshForDispCalc(char *cmd);
@@ -174,11 +174,11 @@ extern vector<BCTData> vbct;
 
 inline
 void Cross(double ax, double ay, double az, double bx, double by, double bz,
-		double *prodx, double *prody, double *prodz) {
-	(*prodx) = ay * bz - az * by;
-	(*prody) = -(ax * bz - az * bx);
-	(*prodz) = ax * by - ay * bx;
-	return;
+        double *prodx, double *prody, double *prodz) {
+    (*prodx) = ay * bz - az * by;
+    (*prody) = -(ax * bz - az * bx);
+    (*prodz) = ax * by - ay * bx;
+    return;
 }
 
 // =======
@@ -187,251 +187,251 @@ void Cross(double ax, double ay, double az, double bx, double by, double bz,
 
 inline
 double Dot(double ax, double ay, double az, double bx, double by, double bz) {
-	double product;
+    double product;
 
-	product = ax * bx + ay * by + az * bz;
-	return product;
+    product = ax * bx + ay * by + az * bz;
+    return product;
 }
 
 int cmd_mesh_vtu(char *cmd) {
 
-	int i;
+    int i;
 
-	// enter
-	debugprint(stddbg, "Entering cmd_mesh_vtu.\n");
+    // enter
+    debugprint(stddbg, "Entering cmd_mesh_vtu.\n");
 
-	// parse command string for filename
-	char meshfn[MAXPATHLEN];
-	meshfn[0] = '\0';
-	parseCmdStr(cmd, meshfn);
+    // parse command string for filename
+    char meshfn[MAXPATHLEN];
+    meshfn[0] = '\0';
+    parseCmdStr(cmd, meshfn);
 
-	// check file exists
-	FILE* fp = NULL;
-	if ((fp = fopen(meshfn, "r")) == NULL) {
-		fprintf(stderr, "ERROR: could not open file (%s).", meshfn);
-		return CV_ERROR;
-	} else {
-		fclose(fp);
-	}
+    // check file exists
+    FILE* fp = NULL;
+    if ((fp = fopen(meshfn, "r")) == NULL) {
+        fprintf(stderr, "ERROR: could not open file (%s).", meshfn);
+        return CV_ERROR;
+    } else {
+        fclose(fp);
+    }
 
-	vtkXMLUnstructuredGridReader* reader = vtkXMLUnstructuredGridReader::New();
-	reader->SetFileName(meshfn);
-	reader->Update();
+    vtkXMLUnstructuredGridReader* reader = vtkXMLUnstructuredGridReader::New();
+    reader->SetFileName(meshfn);
+    reader->Update();
 
-	vtkUnstructuredGrid* ug = NULL;
-	ug = reader->GetOutput();
-	if (ug == NULL) {
-		fprintf(stderr, "ERROR: problems parsing file (%s).", meshfn);
-		return CV_ERROR;
-	}
+    vtkUnstructuredGrid* ug = NULL;
+    ug = reader->GetOutput();
+    if (ug == NULL) {
+        fprintf(stderr, "ERROR: problems parsing file (%s).", meshfn);
+        return CV_ERROR;
+    }
 
-	// never run scalar problems anymore
+    // never run scalar problems anymore
 
-	numSolnVars_ = 5;
+    numSolnVars_ = 5;
 
-	// set num nodes and elements
+    // set num nodes and elements
 
-	numNodes_ = ug->GetNumberOfPoints();
-	numElements_ = ug->GetNumberOfCells();
+    numNodes_ = ug->GetNumberOfPoints();
+    numElements_ = ug->GetNumberOfCells();
 
-	debugprint(stddbg, "  Number of Nodes (%i)\n", numNodes_);
-	debugprint(stddbg, "  Number of Elements (%i).\n", numElements_);
+    debugprint(stddbg, "  Number of Nodes (%i)\n", numNodes_);
+    debugprint(stddbg, "  Number of Elements (%i).\n", numElements_);
 
-	// find the number of edges in the entire mesh
+    // find the number of edges in the entire mesh
 
-	vtkExtractEdges* extractEdges = vtkExtractEdges::New();
-	extractEdges->SetInputDataObject(ug);
-	extractEdges->Update();
-	numMeshEdges_ = extractEdges->GetOutput()->GetNumberOfCells();
-	extractEdges->Delete();
+    vtkExtractEdges* extractEdges = vtkExtractEdges::New();
+    extractEdges->SetInputDataObject(ug);
+    extractEdges->Update();
+    numMeshEdges_ = extractEdges->GetOutput()->GetNumberOfCells();
+    extractEdges->Delete();
 
-	// find exterior surface
+    // find exterior surface
 
-	vtkGeometryFilter* surfFilt = vtkGeometryFilter::New();
-	surfFilt->MergingOff();
-	surfFilt->SetInputDataObject(ug);
-	surfFilt->Update();
-	vtkCleanPolyData* cleaner = vtkCleanPolyData::New();
-	cleaner->PointMergingOff();
-	cleaner->PieceInvariantOff();
-	cleaner->SetInputDataObject(surfFilt->GetOutput());
-	cleaner->Update();
+    vtkGeometryFilter* surfFilt = vtkGeometryFilter::New();
+    surfFilt->MergingOff();
+    surfFilt->SetInputDataObject(ug);
+    surfFilt->Update();
+    vtkCleanPolyData* cleaner = vtkCleanPolyData::New();
+    cleaner->PointMergingOff();
+    cleaner->PieceInvariantOff();
+    cleaner->SetInputDataObject(surfFilt->GetOutput());
+    cleaner->Update();
 
-	vtkPolyData *bdryPD = cleaner->GetOutput();
+    vtkPolyData *bdryPD = cleaner->GetOutput();
 
-	bdryPD->GetPointData()->SetActiveScalars("GlobalNodeID");
-	bdryPD->GetCellData()->SetActiveScalars("GlobalElementID");
+    bdryPD->GetPointData()->SetActiveScalars("GlobalNodeID");
+    bdryPD->GetCellData()->SetActiveScalars("GlobalElementID");
 
-	numBoundaryFaces_ = bdryPD->GetNumberOfCells();
+    numBoundaryFaces_ = bdryPD->GetNumberOfCells();
 
-	// calculate number of total mesh faces
-	numMeshFaces_ = (numElements_ * 4 - numBoundaryFaces_) / 2
-			+ numBoundaryFaces_;
+    // calculate number of total mesh faces
+    numMeshFaces_ = (numElements_ * 4 - numBoundaryFaces_) / 2
+            + numBoundaryFaces_;
 
-	debugprint(stddbg, "  Number of Boundary Faces (%i)\n", numBoundaryFaces_);
-	debugprint(stddbg, "  Number of Mesh faces (%i).\n", numMeshFaces_);
+    debugprint(stddbg, "  Number of Boundary Faces (%i)\n", numBoundaryFaces_);
+    debugprint(stddbg, "  Number of Mesh faces (%i).\n", numMeshFaces_);
 
-	int eof = 0;
-	int n0, n1, n2, n3;
-	int elementId;
+    int eof = 0;
+    int n0, n1, n2, n3;
+    int elementId;
 
-	//
-	// nodes
-	//
+    //
+    // nodes
+    //
 
-	if (numNodes_ == 0) {
-		fprintf(stderr,
-				"ERROR:  Must specify number of nodes before you read them in!\n");
-		return CV_ERROR;
-	}
+    if (numNodes_ == 0) {
+        fprintf(stderr,
+                "ERROR:  Must specify number of nodes before you read them in!\n");
+        return CV_ERROR;
+    }
 
-	nodes_ = new double[3 * numNodes_];
+    nodes_ = new double[3 * numNodes_];
 
-	double pt[3];
-	int nodeId;
+    double pt[3];
+    int nodeId;
 
-	ug->GetPointData()->SetActiveScalars("GlobalNodeID");
-	ug->GetCellData()->SetActiveScalars("GlobalElementID");
+    ug->GetPointData()->SetActiveScalars("GlobalNodeID");
+    ug->GetCellData()->SetActiveScalars("GlobalElementID");
 
-	for (i = 0; i < numNodes_; i++) {
-		ug->GetPoints()->GetPoint(i, pt);
-		nodeId = ug->GetPointData()->GetScalars()->GetTuple1(i);
-		nodes_[0 * numNodes_ + nodeId - 1] = pt[0];
-		nodes_[1 * numNodes_ + nodeId - 1] = pt[1];
-		nodes_[2 * numNodes_ + nodeId - 1] = pt[2];
-		debugprint(stddbg, "  Node (%i) : %lf %lf %lf\n", nodeId, pt[0], pt[1],
-				pt[2]);
-	}
+    for (i = 0; i < numNodes_; i++) {
+        ug->GetPoints()->GetPoint(i, pt);
+        nodeId = ug->GetPointData()->GetScalars()->GetTuple1(i);
+        nodes_[0 * numNodes_ + nodeId - 1] = pt[0];
+        nodes_[1 * numNodes_ + nodeId - 1] = pt[1];
+        nodes_[2 * numNodes_ + nodeId - 1] = pt[2];
+        debugprint(stddbg, "  Node (%i) : %lf %lf %lf\n", nodeId, pt[0], pt[1],
+                pt[2]);
+    }
 
-	// do work
-	if (numElements_ == 0) {
-		fprintf(stderr,
-				"ERROR:  Must specify number of elements before you read them in!\n");
-		return CV_ERROR;
-	}
+    // do work
+    if (numElements_ == 0) {
+        fprintf(stderr,
+                "ERROR:  Must specify number of elements before you read them in!\n");
+        return CV_ERROR;
+    }
 
-	vtkIdList* ptids = vtkIdList::New();
-	ptids->Allocate(10, 10);
-	ptids->Initialize();
+    vtkIdList* ptids = vtkIdList::New();
+    ptids->Allocate(10, 10);
+    ptids->Initialize();
 
-	elements_ = new int[4 * numElements_];
+    elements_ = new int[4 * numElements_];
 
-	vtkCellArray *cells = ug->GetCells();
-	cells->InitTraversal();
+    vtkCellArray *cells = ug->GetCells();
+    cells->InitTraversal();
 
-	for (int i = 0; i < numElements_; i++) {
+    for (int i = 0; i < numElements_; i++) {
 
-		ptids->Reset();
-		cells->GetCell(5 * i, ptids);
-		if (ptids->GetNumberOfIds() != 4) {
-			fprintf(stderr, "ERROR:  invalid number of ids in cell (%i)!",
-					ptids->GetNumberOfIds());
-			return CV_ERROR;
-		}
-		elementId = ug->GetCellData()->GetScalars()->GetTuple1(i);
-		n0 = ug->GetPointData()->GetScalars()->GetTuple1(ptids->GetId(0));
-		n1 = ug->GetPointData()->GetScalars()->GetTuple1(ptids->GetId(1));
-		n2 = ug->GetPointData()->GetScalars()->GetTuple1(ptids->GetId(2));
-		n3 = ug->GetPointData()->GetScalars()->GetTuple1(ptids->GetId(3));
+        ptids->Reset();
+        cells->GetCell(5 * i, ptids);
+        if (ptids->GetNumberOfIds() != 4) {
+            fprintf(stderr, "ERROR:  invalid number of ids in cell (%i)!",
+                    ptids->GetNumberOfIds());
+            return CV_ERROR;
+        }
+        elementId = ug->GetCellData()->GetScalars()->GetTuple1(i);
+        n0 = ug->GetPointData()->GetScalars()->GetTuple1(ptids->GetId(0));
+        n1 = ug->GetPointData()->GetScalars()->GetTuple1(ptids->GetId(1));
+        n2 = ug->GetPointData()->GetScalars()->GetTuple1(ptids->GetId(2));
+        n3 = ug->GetPointData()->GetScalars()->GetTuple1(ptids->GetId(3));
 
-		int j0 = 0;
-		int j1 = 0;
-		int j2 = 0;
-		int j3 = 0;
+        int j0 = 0;
+        int j1 = 0;
+        int j2 = 0;
+        int j3 = 0;
 
-		check_node_order(n0, n1, n2, n3, elementId, &j0, &j1, &j2, &j3);
+        check_node_order(n0, n1, n2, n3, elementId, &j0, &j1, &j2, &j3);
 
-		elements_[0 * numElements_ + elementId - 1] = j0;
-		elements_[1 * numElements_ + elementId - 1] = j1;
-		elements_[2 * numElements_ + elementId - 1] = j2;
-		elements_[3 * numElements_ + elementId - 1] = j3;
+        elements_[0 * numElements_ + elementId - 1] = j0;
+        elements_[1 * numElements_ + elementId - 1] = j1;
+        elements_[2 * numElements_ + elementId - 1] = j2;
+        elements_[3 * numElements_ + elementId - 1] = j3;
 
-	}
+    }
 
-	//
-	// Boundary Faces
-	//
+    //
+    // Boundary Faces
+    //
 
-	// init data first time this function is called
-	if (boundaryElements_ == NULL) {
-		boundaryElements_ = new int*[4];
-		boundaryElements_[0] = new int[numMeshFaces_];
-		boundaryElements_[1] = new int[numMeshFaces_];
-		boundaryElements_[2] = new int[numMeshFaces_];
-		boundaryElements_[3] = new int[numMeshFaces_];
-		boundaryElementsIds_ = new int[numMeshFaces_];
-	}
+    // init data first time this function is called
+    if (boundaryElements_ == NULL) {
+        boundaryElements_ = new int*[4];
+        boundaryElements_[0] = new int[numMeshFaces_];
+        boundaryElements_[1] = new int[numMeshFaces_];
+        boundaryElements_[2] = new int[numMeshFaces_];
+        boundaryElements_[3] = new int[numMeshFaces_];
+        boundaryElementsIds_ = new int[numMeshFaces_];
+    }
 
-	cells = bdryPD->GetPolys();
-	cells->InitTraversal();
+    cells = bdryPD->GetPolys();
+    cells->InitTraversal();
 
-	for (i = 0; i < cells->GetNumberOfCells(); i++) {
-		ptids->Reset();
-		cells->GetCell(4 * i, ptids);
-		if (ptids->GetNumberOfIds() != 3) {
-			fprintf(stderr, "ERROR:  invalid number of ids in cell (%i)!",
-					ptids->GetNumberOfIds());
-			return CV_ERROR;
-		}
-		elementId = bdryPD->GetCellData()->GetScalars()->GetTuple1(i);
-		n0 = bdryPD->GetPointData()->GetScalars()->GetTuple1(ptids->GetId(0));
-		n1 = bdryPD->GetPointData()->GetScalars()->GetTuple1(ptids->GetId(1));
-		n2 = bdryPD->GetPointData()->GetScalars()->GetTuple1(ptids->GetId(2));
+    for (i = 0; i < cells->GetNumberOfCells(); i++) {
+        ptids->Reset();
+        cells->GetCell(4 * i, ptids);
+        if (ptids->GetNumberOfIds() != 3) {
+            fprintf(stderr, "ERROR:  invalid number of ids in cell (%i)!",
+                    ptids->GetNumberOfIds());
+            return CV_ERROR;
+        }
+        elementId = bdryPD->GetCellData()->GetScalars()->GetTuple1(i);
+        n0 = bdryPD->GetPointData()->GetScalars()->GetTuple1(ptids->GetId(0));
+        n1 = bdryPD->GetPointData()->GetScalars()->GetTuple1(ptids->GetId(1));
+        n2 = bdryPD->GetPointData()->GetScalars()->GetTuple1(ptids->GetId(2));
 
-		n3 = -1;
+        n3 = -1;
 
-		int j0 = 0;
-		int j1 = 0;
-		int j2 = 0;
-		int j3 = 0;
+        int j0 = 0;
+        int j1 = 0;
+        int j2 = 0;
+        int j3 = 0;
 
-		check_node_order(n0, n1, n2, n3, elementId, &j0, &j1, &j2, &j3);
+        check_node_order(n0, n1, n2, n3, elementId, &j0, &j1, &j2, &j3);
 
-		boundaryElements_[0][i] = j0;
-		boundaryElements_[1][i] = j1;
-		boundaryElements_[2][i] = j2;
-		boundaryElements_[3][i] = j3;
+        boundaryElements_[0][i] = j0;
+        boundaryElements_[1][i] = j1;
+        boundaryElements_[2][i] = j2;
+        boundaryElements_[3][i] = j3;
 
-		debugprint(stddbg, "  Boundary Element (%i) (%i): %i %i %i %i\n", i,
-				elementId, j0, j1, j2, j3);
+        debugprint(stddbg, "  Boundary Element (%i) (%i): %i %i %i %i\n", i,
+                elementId, j0, j1, j2, j3);
 
-		// note that I assume element numbering starts at 1,
-		// whereas flow solver assumes it started at zero!!
-		boundaryElementsIds_[i] = elementId - 1;
+        // note that I assume element numbering starts at 1,
+        // whereas flow solver assumes it started at zero!!
+        boundaryElementsIds_[i] = elementId - 1;
 
-	}
+    }
 
-	// cleanup
-	ptids->Delete();
-	cleaner->Delete();
-	surfFilt->Delete();
-	reader->Delete();
+    // cleanup
+    ptids->Delete();
+    cleaner->Delete();
+    surfFilt->Delete();
+    reader->Delete();
 
-	//
-	//  create some additional internal data structs
-	//
+    //
+    //  create some additional internal data structs
+    //
 
-	if (iBC_ == NULL) {
-		iBC_ = new int[numNodes_];
-		for (i = 0; i < numNodes_; i++) {
-			iBC_[i] = 0;
-		}
-	}
+    if (iBC_ == NULL) {
+        iBC_ = new int[numNodes_];
+        for (i = 0; i < numNodes_; i++) {
+            iBC_[i] = 0;
+        }
+    }
 
-	if (iBCB_ == NULL) {
-		iBCB_ = new int[2 * numBoundaryFaces_];
-		BCB_ = new double[numBoundaryFaces_ * 6];
-		for (i = 0; i < 2 * numBoundaryFaces_; i++) {
-			iBCB_[i] = 0;
-		}
-		for (i = 0; i < numBoundaryFaces_; i++) {
-			BCB_[i] = 0.0;
-		}
-	}
+    if (iBCB_ == NULL) {
+        iBCB_ = new int[2 * numBoundaryFaces_];
+        BCB_ = new double[numBoundaryFaces_ * 6];
+        for (i = 0; i < 2 * numBoundaryFaces_; i++) {
+            iBCB_[i] = 0;
+        }
+        for (i = 0; i < numBoundaryFaces_; i++) {
+            BCB_[i] = 0.0;
+        }
+    }
 
-	debugprint(stddbg, "Exiting cmd_mesh_vtu.\n");
+    debugprint(stddbg, "Exiting cmd_mesh_vtu.\n");
 
-	return CV_OK;
+    return CV_OK;
 
 }
 
@@ -446,615 +446,625 @@ int cmd_mesh_vtu(char *cmd) {
  */
 int cmd_mesh_and_adjncy_vtu(char *cmd) {
 
-	int i;
+    int i;
 
-	// enter
-	debugprint(stddbg, "Entering cmd_mesh_and_adjncy_vtu.\n");
+    // enter
+    debugprint(stddbg, "Entering cmd_mesh_and_adjncy_vtu.\n");
 
-	// parse command string for filename
-	char meshfn[MAXPATHLEN];
-	meshfn[0] = '\0';
-	parseCmdStr(cmd, meshfn);
+    // parse command string for filename
+    char meshfn[MAXPATHLEN];
+    meshfn[0] = '\0';
+    parseCmdStr(cmd, meshfn);
 
-	// check file exists
-	FILE* fp = NULL;
-	if ((fp = fopen(meshfn, "r")) == NULL) {
-		fprintf(stderr, "ERROR: could not open file (%s).", meshfn);
-		return CV_ERROR;
-	} else {
-		fclose(fp);
-	}
+    // check file exists
+    FILE* fp = NULL;
+    if ((fp = fopen(meshfn, "r")) == NULL) {
+        fprintf(stderr, "ERROR: could not open file (%s).", meshfn);
+        return CV_ERROR;
+    } else {
+        fclose(fp);
+    }
 
-	vtkXMLUnstructuredGridReader* reader = vtkXMLUnstructuredGridReader::New();
-	reader->SetFileName(meshfn);
-	reader->Update();
+    vtkXMLUnstructuredGridReader* reader = vtkXMLUnstructuredGridReader::New();
+    reader->SetFileName(meshfn);
+    reader->Update();
 
-	vtkUnstructuredGrid* ug = NULL;
-	ug = reader->GetOutput();
-	if (ug == NULL) {
-		fprintf(stderr, "ERROR: problems parsing file (%s).", meshfn);
-		return CV_ERROR;
-	}
+    vtkUnstructuredGrid* ug = NULL;
+    ug = reader->GetOutput();
+    if (ug == NULL) {
+        fprintf(stderr, "ERROR: problems parsing file (%s).", meshfn);
+        return CV_ERROR;
+    }
 
-	// never run scalar problems anymore
+    // never run scalar problems anymore
 
-	numSolnVars_ = 5;
+    numSolnVars_ = 5;
 
-	// set num nodes and elements
+    // set num nodes and elements
 
-	numNodes_ = ug->GetNumberOfPoints();
-	numElements_ = ug->GetNumberOfCells();
+    numNodes_ = ug->GetNumberOfPoints();
+    numElements_ = ug->GetNumberOfCells();
 
-	debugprint(stddbg, "  Number of Nodes (%i)\n", numNodes_);
-	debugprint(stddbg, "  Number of Elements (%i).\n", numElements_);
+    debugprint(stddbg, "  Number of Nodes (%i)\n", numNodes_);
+    debugprint(stddbg, "  Number of Elements (%i).\n", numElements_);
 
-	// find the number of edges in the entire mesh
+    // find the number of edges in the entire mesh
 
-	vtkExtractEdges* extractEdges = vtkExtractEdges::New();
-	extractEdges->SetInputDataObject(ug);
-	extractEdges->Update();
-	numMeshEdges_ = extractEdges->GetOutput()->GetNumberOfCells();
-	extractEdges->Delete();
+    vtkExtractEdges* extractEdges = vtkExtractEdges::New();
+    extractEdges->SetInputDataObject(ug);
+    extractEdges->Update();
+    numMeshEdges_ = extractEdges->GetOutput()->GetNumberOfCells();
+    extractEdges->Delete();
 
-	// find exterior surface
+    // find exterior surface
 
-	vtkGeometryFilter* surfFilt = vtkGeometryFilter::New();
-	surfFilt->MergingOff();
-	surfFilt->SetInputDataObject(ug);
-	surfFilt->Update();
-	vtkCleanPolyData* cleaner = vtkCleanPolyData::New();
-	cleaner->PointMergingOff();
-	cleaner->PieceInvariantOff();
-	cleaner->SetInputDataObject(surfFilt->GetOutput());
-	cleaner->Update();
+    vtkGeometryFilter* surfFilt = vtkGeometryFilter::New();
+    surfFilt->MergingOff();
+    surfFilt->SetInputDataObject(ug);
+    surfFilt->Update();
+    vtkCleanPolyData* cleaner = vtkCleanPolyData::New();
+    cleaner->PointMergingOff();
+    cleaner->PieceInvariantOff();
+    cleaner->SetInputDataObject(surfFilt->GetOutput());
+    cleaner->Update();
 
-	vtkPolyData *bdryPD = cleaner->GetOutput();
+    vtkPolyData *bdryPD = cleaner->GetOutput();
 
-	bdryPD->GetPointData()->SetActiveScalars("GlobalNodeID");
-	bdryPD->GetCellData()->SetActiveScalars("GlobalElementID");
+    bdryPD->GetPointData()->SetActiveScalars("GlobalNodeID");
+    bdryPD->GetCellData()->SetActiveScalars("GlobalElementID");
 
-	numBoundaryFaces_ = bdryPD->GetNumberOfCells();
+    numBoundaryFaces_ = bdryPD->GetNumberOfCells();
 
-	// calculate number of total mesh faces
-	numMeshFaces_ = (numElements_ * 4 - numBoundaryFaces_) / 2
-			+ numBoundaryFaces_;
+    // calculate number of total mesh faces
+    numMeshFaces_ = (numElements_ * 4 - numBoundaryFaces_) / 2
+            + numBoundaryFaces_;
 
-	debugprint(stddbg, "  Number of Boundary Faces (%i)\n", numBoundaryFaces_);
-	debugprint(stddbg, "  Number of Mesh faces (%i).\n", numMeshFaces_);
+    debugprint(stddbg, "  Number of Boundary Faces (%i)\n", numBoundaryFaces_);
+    debugprint(stddbg, "  Number of Mesh faces (%i).\n", numMeshFaces_);
 
-	int eof = 0;
-	int n0, n1, n2, n3;
-	int elementId;
+    int eof = 0;
+    int n0, n1, n2, n3;
+    int elementId;
 
-	//
-	// nodes
-	//
+    //
+    // nodes
+    //
 
-	if (numNodes_ == 0) {
-		fprintf(stderr,
-				"ERROR:  Must specify number of nodes before you read them in!\n");
-		return CV_ERROR;
-	}
+    if (numNodes_ == 0) {
+        fprintf(stderr,
+                "ERROR:  Must specify number of nodes before you read them in!\n");
+        return CV_ERROR;
+    }
 
-	nodes_ = new double[3 * numNodes_];
+    nodes_ = new double[3 * numNodes_];
 
-	double pt[3];
-	int nodeId;
+    double pt[3];
+    int nodeId;
 
-	ug->GetPointData()->SetActiveScalars("GlobalNodeID");
-	ug->GetCellData()->SetActiveScalars("GlobalElementID");
+    ug->GetPointData()->SetActiveScalars("GlobalNodeID");
+    ug->GetCellData()->SetActiveScalars("GlobalElementID");
 
-	for (i = 0; i < numNodes_; i++) {
-		ug->GetPoints()->GetPoint(i, pt);
-		nodeId = ug->GetPointData()->GetScalars()->GetTuple1(i);
-		nodes_[0 * numNodes_ + nodeId - 1] = pt[0];
-		nodes_[1 * numNodes_ + nodeId - 1] = pt[1];
-		nodes_[2 * numNodes_ + nodeId - 1] = pt[2];
-		debugprint(stddbg, "  Node (%i) : %lf %lf %lf\n", nodeId, pt[0], pt[1],
-				pt[2]);
-	}
+    for (i = 0; i < numNodes_; i++) {
+        ug->GetPoints()->GetPoint(i, pt);
+        nodeId = ug->GetPointData()->GetScalars()->GetTuple1(i);
+        nodes_[0 * numNodes_ + nodeId - 1] = pt[0];
+        nodes_[1 * numNodes_ + nodeId - 1] = pt[1];
+        nodes_[2 * numNodes_ + nodeId - 1] = pt[2];
+        debugprint(stddbg, "  Node (%i) : %lf %lf %lf\n", nodeId, pt[0], pt[1],
+                pt[2]);
+    }
 
-	// do work
-	if (numElements_ == 0) {
-		fprintf(stderr,
-				"ERROR:  Must specify number of elements before you read them in!\n");
-		return CV_ERROR;
-	}
+    // do work
+    if (numElements_ == 0) {
+        fprintf(stderr,
+                "ERROR:  Must specify number of elements before you read them in!\n");
+        return CV_ERROR;
+    }
 
-	vtkIdList* ptids = vtkIdList::New();
-	ptids->Allocate(10, 10);
-	ptids->Initialize();
+    vtkIdList* ptids = vtkIdList::New();
+    ptids->Allocate(10, 10);
+    ptids->Initialize();
 
-	elements_ = new int[4 * numElements_];
+    elements_ = new int[4 * numElements_];
 
-	vtkCellArray *cells = ug->GetCells();
-	cells->InitTraversal();
+    vtkCellArray *cells = ug->GetCells();
+    cells->InitTraversal();
 
-	for (int i = 0; i < numElements_; i++) {
+    for (int i = 0; i < numElements_; i++) {
 
-		ptids->Reset();
-		cells->GetCell(5 * i, ptids);
-		if (ptids->GetNumberOfIds() != 4) {
-			fprintf(stderr, "ERROR:  invalid number of ids in cell (%i)!",
-					ptids->GetNumberOfIds());
-			return CV_ERROR;
-		}
-		elementId = ug->GetCellData()->GetScalars()->GetTuple1(i);
-		n0 = ug->GetPointData()->GetScalars()->GetTuple1(ptids->GetId(0));
-		n1 = ug->GetPointData()->GetScalars()->GetTuple1(ptids->GetId(1));
-		n2 = ug->GetPointData()->GetScalars()->GetTuple1(ptids->GetId(2));
-		n3 = ug->GetPointData()->GetScalars()->GetTuple1(ptids->GetId(3));
+        ptids->Reset();
+        cells->GetCell(5 * i, ptids);
+        if (ptids->GetNumberOfIds() != 4) {
+            fprintf(stderr, "ERROR:  invalid number of ids in cell (%i)!",
+                    ptids->GetNumberOfIds());
+            return CV_ERROR;
+        }
+        elementId = ug->GetCellData()->GetScalars()->GetTuple1(i);
+        n0 = ug->GetPointData()->GetScalars()->GetTuple1(ptids->GetId(0));
+        n1 = ug->GetPointData()->GetScalars()->GetTuple1(ptids->GetId(1));
+        n2 = ug->GetPointData()->GetScalars()->GetTuple1(ptids->GetId(2));
+        n3 = ug->GetPointData()->GetScalars()->GetTuple1(ptids->GetId(3));
 
-		int j0 = 0;
-		int j1 = 0;
-		int j2 = 0;
-		int j3 = 0;
+        int j0 = 0;
+        int j1 = 0;
+        int j2 = 0;
+        int j3 = 0;
 
-		check_node_order(n0, n1, n2, n3, elementId, &j0, &j1, &j2, &j3);
+        check_node_order(n0, n1, n2, n3, elementId, &j0, &j1, &j2, &j3);
 
-		elements_[0 * numElements_ + elementId - 1] = j0;
-		elements_[1 * numElements_ + elementId - 1] = j1;
-		elements_[2 * numElements_ + elementId - 1] = j2;
-		elements_[3 * numElements_ + elementId - 1] = j3;
+        elements_[0 * numElements_ + elementId - 1] = j0;
+        elements_[1 * numElements_ + elementId - 1] = j1;
+        elements_[2 * numElements_ + elementId - 1] = j2;
+        elements_[3 * numElements_ + elementId - 1] = j3;
 
-	}
+    }
 
-	//
-	// Boundary Faces
-	//
+    //
+    // Boundary Faces
+    //
 
-	// init data first time this function is called
-	if (boundaryElements_ == NULL) {
-		boundaryElements_ = new int*[4];
-		boundaryElements_[0] = new int[numMeshFaces_];
-		boundaryElements_[1] = new int[numMeshFaces_];
-		boundaryElements_[2] = new int[numMeshFaces_];
-		boundaryElements_[3] = new int[numMeshFaces_];
-		boundaryElementsIds_ = new int[numMeshFaces_];
-	}
+    // init data first time this function is called
+    if (boundaryElements_ == NULL) {
+        boundaryElements_ = new int*[4];
+        boundaryElements_[0] = new int[numMeshFaces_];
+        boundaryElements_[1] = new int[numMeshFaces_];
+        boundaryElements_[2] = new int[numMeshFaces_];
+        boundaryElements_[3] = new int[numMeshFaces_];
+        boundaryElementsIds_ = new int[numMeshFaces_];
+    }
 
-	cells = bdryPD->GetPolys();
-	cells->InitTraversal();
+    cells = bdryPD->GetPolys();
+    cells->InitTraversal();
 
-	for (i = 0; i < cells->GetNumberOfCells(); i++) {
-		ptids->Reset();
-		cells->GetCell(4 * i, ptids);
-		if (ptids->GetNumberOfIds() != 3) {
-			fprintf(stderr, "ERROR:  invalid number of ids in cell (%i)!",
-					ptids->GetNumberOfIds());
-			return CV_ERROR;
-		}
-		elementId = bdryPD->GetCellData()->GetScalars()->GetTuple1(i);
-		n0 = bdryPD->GetPointData()->GetScalars()->GetTuple1(ptids->GetId(0));
-		n1 = bdryPD->GetPointData()->GetScalars()->GetTuple1(ptids->GetId(1));
-		n2 = bdryPD->GetPointData()->GetScalars()->GetTuple1(ptids->GetId(2));
+    for (i = 0; i < cells->GetNumberOfCells(); i++) {
+        ptids->Reset();
+        cells->GetCell(4 * i, ptids);
+        if (ptids->GetNumberOfIds() != 3) {
+            fprintf(stderr, "ERROR:  invalid number of ids in cell (%i)!",
+                    ptids->GetNumberOfIds());
+            return CV_ERROR;
+        }
+        elementId = bdryPD->GetCellData()->GetScalars()->GetTuple1(i);
+        n0 = bdryPD->GetPointData()->GetScalars()->GetTuple1(ptids->GetId(0));
+        n1 = bdryPD->GetPointData()->GetScalars()->GetTuple1(ptids->GetId(1));
+        n2 = bdryPD->GetPointData()->GetScalars()->GetTuple1(ptids->GetId(2));
 
-		n3 = -1;
+        n3 = -1;
 
-		int j0 = 0;
-		int j1 = 0;
-		int j2 = 0;
-		int j3 = 0;
+        int j0 = 0;
+        int j1 = 0;
+        int j2 = 0;
+        int j3 = 0;
 
-		check_node_order(n0, n1, n2, n3, elementId, &j0, &j1, &j2, &j3);
+        check_node_order(n0, n1, n2, n3, elementId, &j0, &j1, &j2, &j3);
 
-		boundaryElements_[0][i] = j0;
-		boundaryElements_[1][i] = j1;
-		boundaryElements_[2][i] = j2;
-		boundaryElements_[3][i] = j3;
+        boundaryElements_[0][i] = j0;
+        boundaryElements_[1][i] = j1;
+        boundaryElements_[2][i] = j2;
+        boundaryElements_[3][i] = j3;
 
-		debugprint(stddbg, "  Boundary Element (%i) (%i): %i %i %i %i\n", i,
-				elementId, j0, j1, j2, j3);
+        debugprint(stddbg, "  Boundary Element (%i) (%i): %i %i %i %i\n", i,
+                elementId, j0, j1, j2, j3);
 
-		// note that I assume element numbering starts at 1,
-		// whereas flow solver assumes it started at zero!!
-		boundaryElementsIds_[i] = elementId - 1;
+        // note that I assume element numbering starts at 1,
+        // whereas flow solver assumes it started at zero!!
+        boundaryElementsIds_[i] = elementId - 1;
 
-	}
+    }
 
-	//
-	//  create some additional internal data structs
-	//
+    //
+    //  create some additional internal data structs
+    //
 
-	if (iBC_ == NULL) {
-		iBC_ = new int[numNodes_];
-		for (i = 0; i < numNodes_; i++) {
-			iBC_[i] = 0;
-		}
-	}
+    if (iBC_ == NULL) {
+        iBC_ = new int[numNodes_];
+        for (i = 0; i < numNodes_; i++) {
+            iBC_[i] = 0;
+        }
+    }
 
-	if (iBCB_ == NULL) {
-		iBCB_ = new int[2 * numBoundaryFaces_];
-		BCB_ = new double[numBoundaryFaces_ * 6];
-		for (i = 0; i < 2 * numBoundaryFaces_; i++) {
-			iBCB_[i] = 0;
-		}
-		for (i = 0; i < numBoundaryFaces_; i++) {
-			BCB_[i] = 0.0;
-		}
-	}
+    if (iBCB_ == NULL) {
+        iBCB_ = new int[2 * numBoundaryFaces_];
+        BCB_ = new double[numBoundaryFaces_ * 6];
+        for (i = 0; i < 2 * numBoundaryFaces_; i++) {
+            iBCB_[i] = 0;
+        }
+        for (i = 0; i < numBoundaryFaces_; i++) {
+            BCB_[i] = 0.0;
+        }
+    }
 
-	//Starting to extract the adjacency information
-	//Define vars
-	int numCells;
-	vtkIdType cellId;
-	vtkIdType meshCellId;
-	vtkIdType p1, p2, p3;
-	vtkIdType npts = 0;
-	vtkIdType *pts = 0;
-	vtkSmartPointer < vtkIdList > ptIds = vtkSmartPointer < vtkIdList > ::New();
-	vtkSmartPointer < vtkIdList > cellIds = vtkSmartPointer < vtkIdList
-			> ::New();
+    //Starting to extract the adjacency information
+    //Define vars
+    int numCells;
+    vtkIdType cellId;
+    vtkIdType meshCellId;
+    vtkIdType p1, p2, p3;
+    vtkIdType npts = 0;
+    vtkIdType *pts = 0;
+    vtkSmartPointer < vtkIdList > ptIds = vtkSmartPointer < vtkIdList > ::New();
+    vtkSmartPointer < vtkIdList > cellIds = vtkSmartPointer < vtkIdList
+            > ::New();
 
-	// do work
-	//
-	ug->GetPointData()->SetActiveScalars("GlobalNodeID");
-	ug->GetCellData()->SetActiveScalars("GlobalElementID");
-	ug->BuildLinks();
-	numCells = ug->GetNumberOfCells();
+    // do work
+    //
+    ug->GetPointData()->SetActiveScalars("GlobalNodeID");
+    ug->GetCellData()->SetActiveScalars("GlobalElementID");
+    ug->BuildLinks();
+    numCells = ug->GetNumberOfCells();
 
-	xadj_ = new int[numCells + 1];
-	adjncy_ = new int[4 * numCells];
-	int adj = 0;
-	int xcheck = 0;
-	xadj_[xcheck] = 0;
+    xadj_ = new int[numCells + 1];
+    adjncy_ = new int[4 * numCells];
+    int adj = 0;
+    int xcheck = 0;
+    xadj_[xcheck] = 0;
 
-	ptIds->SetNumberOfIds(3);
-	for (cellId = 0; cellId < numCells; cellId++) {
-		meshCellId = (int) ug->GetCellData()->GetScalars()->LookupValue(cellId + 1);
-		ug->GetCellPoints(meshCellId, npts, pts);
+    ptIds->SetNumberOfIds(3);
+    for (cellId = 0; cellId < numCells; cellId++) {
+        meshCellId = (int) ug->GetCellData()->GetScalars()->LookupValue(cellId + 1);
+        ug->GetCellPoints(meshCellId, npts, pts);
 
-		for (i = 0; i < npts; i++) {
-			p1 = pts[i];
-			p2 = pts[(i + 1) % (npts)];
-			p3 = pts[(i + 2) % (npts)];
+        for (i = 0; i < npts; i++) {
+            p1 = pts[i];
+            p2 = pts[(i + 1) % (npts)];
+            p3 = pts[(i + 2) % (npts)];
 
-			ptIds->InsertId(0, p1);
-			ptIds->InsertId(1, p2);
-			ptIds->InsertId(2, p3);
+            ptIds->InsertId(0, p1);
+            ptIds->InsertId(1, p2);
+            ptIds->InsertId(2, p3);
 
-			ug->GetCellNeighbors(meshCellId, ptIds, cellIds);
+            ug->GetCellNeighbors(meshCellId, ptIds, cellIds);
 
-			if (cellIds->GetNumberOfIds() != 0) {
-				adjncy_[adj++] = (int) (ug->GetCellData()->GetScalars()->GetTuple1(
-						cellIds->GetId(0)) - 1);
-			}
+            if (cellIds->GetNumberOfIds() != 0) {
+                adjncy_[adj++] = (int) (ug->GetCellData()->GetScalars()->GetTuple1(
+                        cellIds->GetId(0)) - 1);
+            }
 
-		}
-		xadj_[++xcheck] = adj;
-	}
+        }
+        xadj_[++xcheck] = adj;
+    }
 
-	adjncySize_ = adj;
-	xadjSize_ = numCells + 1;
+    adjncySize_ = adj;
+    xadjSize_ = numCells + 1;
 
-	// cleanup
-	ptids->Delete();
-	cleaner->Delete();
-	surfFilt->Delete();
-	reader->Delete();
+    // cleanup
+    ptids->Delete();
+    cleaner->Delete();
+    surfFilt->Delete();
+    reader->Delete();
 
-	debugprint(stddbg, "Exiting cmd_mesh_and_adjncy_vtu.\n");
+    debugprint(stddbg, "Exiting cmd_mesh_and_adjncy_vtu.\n");
 
-	return CV_OK;
+    return CV_OK;
 }
 
 int read_variables_vtu(char* vtufn,string presName, string velName, string dispName,bool dispRequired,
-		string tDName, bool tDRequired, string wpName, bool wpRequired) {
-
-	// enter
-	debugprint(stddbg, "Entering read_variables_vtu.\n");
-
-	// check file exists
-	FILE* fp = NULL;
-	if ((fp = fopen(vtufn, "r")) == NULL) {
-		fprintf(stderr, "ERROR: could not open file (%s).", vtufn);
-		return CV_ERROR;
-	} else {
-		fclose(fp);
-	}
-
-	vtkXMLUnstructuredGridReader* reader = vtkXMLUnstructuredGridReader::New();
-	reader->SetFileName(vtufn);
-	reader->Update();
-
-	vtkUnstructuredGrid* ug = NULL;
-	ug = reader->GetOutput();
-	if (ug == NULL) {
-		fprintf(stderr, "ERROR: problems parsing file (%s).", vtufn);
-		return CV_ERROR;
-	}
-
-	numSolnVars_ = 5;
-
-	// read num nodes
-	numNodes_ = ug->GetNumberOfPoints();
-
-	debugprint(stddbg, "  Number of Nodes (%i)\n", numNodes_);
-
-	if (numNodes_ == 0) {
-		fprintf(stderr, "ERROR:  Needs nodes in (%s)!\n",vtufn);
-		return CV_ERROR;
-	}
-
-	int size = numNodes_ * numSolnVars_;
-
-	int numArrays = ug->GetPointData()->GetNumberOfArrays();
-
-	string IDName="GlobalNodeID";
-
-	string IDArrayName="", presArrayName = "", velArrayName = "", dispArrayName = "", tDArrayName="";
-	string wpArrayName = "";
-
-	for (int i = 0; i < numArrays; i++) {
-		string name = ug->GetPointData()->GetArrayName(i);
+        string tDName, bool tDRequired, string wpName, bool wpRequired) {
+
+    // enter
+    debugprint(stddbg, "Entering read_variables_vtu.\n");
+
+    // check file exists
+    FILE* fp = NULL;
+    if ((fp = fopen(vtufn, "r")) == NULL) {
+        fprintf(stderr, "ERROR: could not open file (%s).", vtufn);
+        return CV_ERROR;
+    } else {
+        fclose(fp);
+    }
+
+    vtkXMLUnstructuredGridReader* reader = vtkXMLUnstructuredGridReader::New();
+    reader->SetFileName(vtufn);
+    reader->Update();
+
+    vtkUnstructuredGrid* ug = NULL;
+    ug = reader->GetOutput();
+    if (ug == NULL) {
+        fprintf(stderr, "ERROR: problems parsing file (%s).", vtufn);
+        return CV_ERROR;
+    }
+
+    numSolnVars_ = 5;
+
+    // read num nodes
+    numNodes_ = ug->GetNumberOfPoints();
+
+    debugprint(stddbg, "  Number of Nodes (%i)\n", numNodes_);
+
+    if (numNodes_ == 0) {
+        fprintf(stderr, "ERROR:  Needs nodes in (%s)!\n",vtufn);
+        return CV_ERROR;
+    }
+
+    int size = numNodes_ * numSolnVars_;
+
+    int numArrays = ug->GetPointData()->GetNumberOfArrays();
+
+    string IDName="GlobalNodeID";
+
+    string IDArrayName="", presArrayName = "", velArrayName = "", dispArrayName = "", tDArrayName="";
+    string wpArrayName = "";
+
+    for (int i = 0; i < numArrays; i++) {
+        string name = ug->GetPointData()->GetArrayName(i);
 
-		size_t found;
-
-		if(IDName!=""){
-			found = name.find(IDName);
-			if (found != string::npos) {
-				IDArrayName = name;
-			}
-		}
+        size_t found;
+
+        if (IDName!="") {
+            found = name.find(IDName);
+            if (found != string::npos) {
+                IDArrayName = name;
+            }
+        }
 
-		if(presName!=""){
-			found = name.find(presName);
-			if (found != string::npos) {
-				presArrayName = name;
-			}
-		}
+        if (presName!="") {
+            found = name.find(presName);
+            if (found != string::npos) {
+                presArrayName = name;
+            }
+        }
 
-		if(velName!=""){
-			found = name.find(velName);
-			if (found != string::npos) {
-				velArrayName = name;
-			}
-		}
+        if (velName!="") {
+            found = name.find(velName);
+            if (found != string::npos) {
+                velArrayName = name;
+            }
+        }
 
-		if(dispName!=""){
-			found = name.find(dispName);
-			if (found != string::npos) {
-				dispArrayName = name;
-			}
-		}
+        if (dispName!="") {
+            found = name.find(dispName);
+            if (found != string::npos) {
+                dispArrayName = name;
+            }
+        }
 
-		if(tDName!=""){
-			found = name.find(tDName);
-			if (found != string::npos) {
-				tDArrayName = name;
-			}
-		}
+        if (tDName!="") {
+            found = name.find(tDName);
+            if (found != string::npos) {
+                tDArrayName = name;
+            }
+        }
 
-		if(wpName!=""){
-			found = name.find(wpName);
-			if (found != string::npos) {
-				wpArrayName = name;
-			}
-		}
-	}
+        if (wpName!="") {
+            found = name.find(wpName);
+            if (found != string::npos) {
+                wpArrayName = name;
+            }
+        }
+    }
 
-	if (IDArrayName == ""){
-		fprintf(stderr, "ERROR:  globalNodeID not found in (%s)!\n",vtufn);
-		return CV_ERROR;
-	}
+    if (IDArrayName == "") {
+        fprintf(stderr, "ERROR:  globalNodeID not found in (%s)!\n",vtufn);
+        return CV_ERROR;
+    }
 
-	if (presArrayName != "" || velArrayName != "") {
-		if(soln_==NULL){
-			soln_ = new double[size];
-		}
-	}
+    if (presArrayName != "" || velArrayName != "") {
+        if (soln_==NULL) {
+            soln_ = new double[size];
+        }
+    }
 
-	if (presArrayName != "") {
-		int nodeID;
-		double pres;
+    if (presArrayName != "") {
+        int nodeID;
+        double pres;
 
-		vtkSmartPointer<vtkIntArray> nodeIDArray =
-				vtkIntArray::SafeDownCast(ug->GetPointData()->GetArray(IDArrayName.c_str()));
+        vtkSmartPointer<vtkIntArray> nodeIDArray =
+                vtkIntArray::SafeDownCast(ug->GetPointData()->GetArray(IDArrayName.c_str()));
 
-		vtkSmartPointer<vtkDoubleArray> presArray =
-				vtkDoubleArray::SafeDownCast(ug->GetPointData()->GetArray(presArrayName.c_str()));
+        vtkSmartPointer<vtkDoubleArray> presArray =
+                vtkDoubleArray::SafeDownCast(ug->GetPointData()->GetArray(presArrayName.c_str()));
 
-		for (int i = 0; i < numNodes_; i++) {
+        for (int i = 0; i < numNodes_; i++) {
 
-			nodeID=nodeIDArray->GetValue(i);
-			pres=presArray->GetValue(i);
+            nodeID=nodeIDArray->GetValue(i);
+            pres=presArray->GetValue(i);
 
-			soln_[0 * numNodes_ + nodeID - 1] = pres;
+            soln_[0 * numNodes_ + nodeID - 1] = pres;
 
-			debugprint(stddbg, "  Node (%i) (p) : %lf \n", nodeID, pres);
+            debugprint(stddbg, "  Node (%i) (p) : %lf \n", nodeID, pres);
 
-		}
+        }
 
-	}else{
-		if(presName!=""){
-			fprintf(stderr, "ERROR: pressure not found in (%s)!\n",vtufn);
-			return CV_ERROR;
-		}
-	}
+    } else {
+        if (presName!="") {
+            fprintf(stderr, "ERROR: pressure not found in (%s)!\n",vtufn);
+            return CV_ERROR;
+        }
+    }
 
-	if (velArrayName != "") {
-		int nodeID;
-		double vel[3];
+    if (velArrayName != "") {
+        int nodeID;
+        double vel[3];
 
-		vtkSmartPointer<vtkIntArray> nodeIDArray =
-				vtkIntArray::SafeDownCast(ug->GetPointData()->GetArray(IDArrayName.c_str()));
+        vtkSmartPointer<vtkIntArray> nodeIDArray =
+                vtkIntArray::SafeDownCast(ug->GetPointData()->GetArray(IDArrayName.c_str()));
 
-		vtkSmartPointer<vtkDoubleArray> velArray =
-				vtkDoubleArray::SafeDownCast(ug->GetPointData()->GetArray(velArrayName.c_str()));
+        vtkSmartPointer<vtkDoubleArray> velArray =
+                vtkDoubleArray::SafeDownCast(ug->GetPointData()->GetArray(velArrayName.c_str()));
 
-		for (int i = 0; i < numNodes_; i++) {
+        for (int i = 0; i < numNodes_; i++) {
 
-			nodeID=nodeIDArray->GetValue(i);
-			velArray->GetTupleValue(i, vel);
+            nodeID=nodeIDArray->GetValue(i);
+            velArray->GetTupleValue(i, vel);
 
-			soln_[1 * numNodes_ + nodeID - 1] = vel[0];
-			soln_[2 * numNodes_ + nodeID - 1] = vel[1];
-			soln_[3 * numNodes_ + nodeID - 1] = vel[2];
+            soln_[1 * numNodes_ + nodeID - 1] = vel[0];
+            soln_[2 * numNodes_ + nodeID - 1] = vel[1];
+            soln_[3 * numNodes_ + nodeID - 1] = vel[2];
 
-			debugprint(stddbg, "  Node (%i) (v1,v2,v3) : %lf %lf %lf\n", nodeID, vel[0],vel[1],vel[2]);
+            debugprint(stddbg, "  Node (%i) (v1,v2,v3) : %lf %lf %lf\n", nodeID, vel[0],vel[1],vel[2]);
 
-		}
+        }
 
-	}else{
-		if(velName!=""){
-			fprintf(stderr, "ERROR:  velocity not found in (%s)!\n",vtufn);
-			return CV_ERROR;
-		}
-	}
+    } else {
+        if (velName!="") {
+            fprintf(stderr, "ERROR:  velocity not found in (%s)!\n",vtufn);
+            return CV_ERROR;
+        }
+    }
 
-	if (dispArrayName != "") {
+    if (dispArrayName != "") {
 
-		dispsoln_ = new double[numNodes_ * 3];
-		int nodeID;
-		double disp[3];
+        dispsoln_ = new double[numNodes_ * 3];
+        int nodeID;
+        double disp[3];
 
-		vtkSmartPointer<vtkIntArray> nodeIDArray =
-				vtkIntArray::SafeDownCast(ug->GetPointData()->GetArray(IDArrayName.c_str()));
+        vtkSmartPointer<vtkIntArray> nodeIDArray =
+                vtkIntArray::SafeDownCast(ug->GetPointData()->GetArray(IDArrayName.c_str()));
 
-		vtkSmartPointer<vtkDoubleArray> dispArray =
-				vtkDoubleArray::SafeDownCast(ug->GetPointData()->GetArray(dispArrayName.c_str()));
+        vtkSmartPointer<vtkDoubleArray> dispArray =
+                vtkDoubleArray::SafeDownCast(ug->GetPointData()->GetArray(dispArrayName.c_str()));
 
-		for (int i = 0; i < numNodes_; i++) {
+        for (int i = 0; i < numNodes_; i++) {
 
-			nodeID=nodeIDArray->GetValue(i);
-			dispArray->GetTupleValue(i,disp);
+            nodeID=nodeIDArray->GetValue(i);
+            dispArray->GetTupleValue(i,disp);
 
-			dispsoln_[0 * numNodes_ + nodeID - 1] = disp[0];
-			dispsoln_[1 * numNodes_ + nodeID - 1] = disp[1];
-			dispsoln_[2 * numNodes_ + nodeID - 1] = disp[2];
+            dispsoln_[0 * numNodes_ + nodeID - 1] = disp[0];
+            dispsoln_[1 * numNodes_ + nodeID - 1] = disp[1];
+            dispsoln_[2 * numNodes_ + nodeID - 1] = disp[2];
 
-			debugprint(stddbg, "  Node (%i) (disp1,disp2,disp3) : %lf %lf %lf\n", nodeID, disp[0],disp[1],disp[2]);
+            debugprint(stddbg, "  Node (%i) (disp1,disp2,disp3) : %lf %lf %lf\n", nodeID, disp[0],disp[1],disp[2]);
 
-		}
-	}else{
-		if(dispName!=""){
-			if(dispRequired){
-				fprintf(stderr, "ERROR:  displacements not found in (%s)!\n",vtufn);
-				return CV_ERROR;
-			}else{
-				fprintf(stdout, "Warning:  displacements not found in (%s)!\n",vtufn);
-			}
-		}
-	}
+        }
+    } else {
+        if (dispName!="") {
+            if (dispRequired){
+                fprintf(stderr, "ERROR:  displacements not found in (%s)!\n",vtufn);
+                return CV_ERROR;
+            } else {
+                fprintf(stdout, "Warning:  displacements not found in (%s)!\n",vtufn);
+            }
+        }
+    }
 
-	if (tDArrayName != "") {
+    if (tDArrayName != "") {
 
-		vtkDataArray* nodeIDArray= ug->GetPointData()->GetArray(IDArrayName.c_str());
-		vtkDataArray* tDArray= ug->GetPointData()->GetArray(tDArrayName.c_str());
-//		int numComponent=vel->GetNumberOfComponents();
+        vtkDataArray* nodeIDArray= ug->GetPointData()->GetArray(IDArrayName.c_str());
+        vtkDataArray* tDArray= ug->GetPointData()->GetArray(tDArrayName.c_str());
+//      int numComponent=vel->GetNumberOfComponents();
 
-//		acc_ = new double[numNodes_ * numComponent];
-		acc_ = new double[numNodes_ * 4];
-		int nodeID;
-		double* ac;
+//      acc_ = new double[numNodes_ * numComponent];
+        acc_ = new double[numNodes_ * 4];
+        int nodeID;
+        double* ac;
 
-		for (int i = 0; i < numNodes_; i++) {
+        for (int i = 0; i < numNodes_; i++) {
 
-			nodeID = nodeIDArray->GetTuple1(i);
-			ac= tDArray->GetTuple4(i);
+            nodeID = nodeIDArray->GetTuple1(i);
+            ac= tDArray->GetTuple4(i);
 
-			acc_[0 * numNodes_ + nodeID - 1] = ac[0];
-			acc_[1 * numNodes_ + nodeID - 1] = ac[1];
-			acc_[2 * numNodes_ + nodeID - 1] = ac[2];
-			acc_[3 * numNodes_ + nodeID - 1] = ac[2];
+            acc_[0 * numNodes_ + nodeID - 1] = ac[0];
+            acc_[1 * numNodes_ + nodeID - 1] = ac[1];
+            acc_[2 * numNodes_ + nodeID - 1] = ac[2];
+            acc_[3 * numNodes_ + nodeID - 1] = ac[2];
 
-			debugprint(stddbg, "  Node (%i) (acc0,acc1,acc2,acc3) : %lf %lf %lf %lf\n", nodeID, ac[0], ac[1],ac[2],ac[3]);
+            debugprint(stddbg, "  Node (%i) (acc0,acc1,acc2,acc3) : %lf %lf %lf %lf\n", nodeID, ac[0], ac[1],ac[2],ac[3]);
 
-		}
-	}else{
-		if(tDName!=""){
-			if(tDRequired){
-				fprintf(stderr, "ERROR:  time derivative of solution not found in (%s)!\n",vtufn);
-				return CV_ERROR;
-			}else{
-				fprintf(stdout, "Warning:  time derivative of solution not found in (%s)!\n",vtufn);
-			}
-		}
-	}
+        }
+    } else {
+        if (tDName!="") {
+            if (tDRequired) {
+                fprintf(stderr, "ERROR:  time derivative of solution not found in (%s)!\n",vtufn);
+                return CV_ERROR;
+            } else {
+                fprintf(stdout, "Warning:  time derivative of solution not found in (%s)!\n",vtufn);
+            }
+        }
+    }
 
-#if(VER_VARWALL == 1)
-	if (wpArrayName != "") {
+#if (VER_VARWALL == 1)
+    if (wpArrayName != "") {
 
-		vtkDataArray* nodeIDArray= ug->GetPointData()->GetArray(IDArrayName.c_str());
-		vtkDataArray* wpArray= ug->GetPointData()->GetArray(wpArrayName.c_str());
+        vtkDataArray* nodeIDArray= ug->GetPointData()->GetArray(IDArrayName.c_str());
+        vtkDataArray* wpArray= ug->GetPointData()->GetArray(wpArrayName.c_str());
 
-		int numWallProp = 5;
+        int numWallProp;
+        if (itissuesuppt) {
+            numWallProp = 5;
+        } else {
+            numWallProp = 2;
+        }
 
-		wallpropsoln_ = new double[numNodes_ * numWallProp];
-		int nodeID;
-		double* wp;
+        wallpropsoln_ = new double[numNodes_ * numWallProp];
+        int nodeID;
+        double* wp;
 
-		for (int i = 0; i < numNodes_; i++) {
+        for (int i = 0; i < numNodes_; i++) {
 
-			nodeID = nodeIDArray->GetTuple1(i);
+            nodeID = nodeIDArray->GetTuple1(i);
 
-			/* EXTERNAL TISSUE SUPPORT - ISL JULY 2019 */
-			wp = wpArray->GetTuple6(i);
+            /* EXTERNAL TISSUE SUPPORT - ISL JULY 2019 */
+            wp = wpArray->GetTuple6(i);
 
-			for (int j = 0; j < numWallProp; j++) {
-				wallpropsoln_[j * numNodes_ + nodeID - 1] = wp[j];
-			}
+            for (int j = 0; j < numWallProp; j++) {
+                wallpropsoln_[j * numNodes_ + nodeID - 1] = wp[j];
+            }
 
-			debugprint(stddbg, "  Node (%i) (thickness,Evw,ksvw,p0vw) : %lf %lf %lf %lf %lf\n",
-				nodeID, wp[0], wp[1], wp[2], wp[3], wp[4]);
+            if (itissuesuppt) {
+                debugprint(stddbg, "  Node (%i) (thickness,Evw,ksvw,csvw,p0vw) : %lf %lf %lf %lf %lf\n",
+                    nodeID, wp[0], wp[1], wp[2], wp[3], wp[4]);
+            } else {
+                debugprint(stddbg, "  Node (%i) (thickness,Evw) : %lf %lf\n",
+                 nodeID, wp[0], wp[1]);
+            }
 
-		}
-	}else{
-		if(wpName!=""){
-			if(wpRequired){
-				fprintf(stderr, "ERROR:  variable wall properties not found in (%s)!\n",vtufn);
-				return CV_ERROR;
-			}else{
-				fprintf(stdout, "Warning:  variable wall properties not found in (%s)!\n",vtufn);
-			}
-		}
-	}
+        }
+    } else {
+        if (wpName!="") {
+            if (wpRequired) {
+                fprintf(stderr, "ERROR:  variable wall properties not found in (%s)!\n",vtufn);
+                return CV_ERROR;
+            } else {
+                fprintf(stdout, "Warning:  variable wall properties not found in (%s)!\n",vtufn);
+            }
+        }
+    }
 
 #endif
 
-	debugprint(stddbg, "Exiting read_variables_vtu.\n");
-	return CV_OK;
+    debugprint(stddbg, "Exiting read_variables_vtu.\n");
+    return CV_OK;
 }
 
 int cmd_read_all_variables_vtu(char *cmd) {
 
-	// enter
-	debugprint(stddbg, "Entering cmd_read_all_variables_vtu.\n");
+    // enter
+    debugprint(stddbg, "Entering cmd_read_all_variables_vtu.\n");
 
-	// parse command string for filename
-	char vtufn[MAXPATHLEN];
-	vtufn[0] = '\0';
-	parseCmdStr(cmd, vtufn);
+    // parse command string for filename
+    char vtufn[MAXPATHLEN];
+    vtufn[0] = '\0';
+    parseCmdStr(cmd, vtufn);
 
-	if(read_variables_vtu(vtufn,"pressure","velocity","displacement",false,"timeDeriv",false,"wallproperty",false)==CV_ERROR){
-		return CV_ERROR;
-	}
-	debugprint(stddbg, "Exiting cmd_read_all_variables_vtu.\n");
-	return CV_OK;
+    if(read_variables_vtu(vtufn,"pressure","velocity","displacement",false,"timeDeriv",false,"wallproperty",false)==CV_ERROR){
+        return CV_ERROR;
+    }
+    debugprint(stddbg, "Exiting cmd_read_all_variables_vtu.\n");
+    return CV_OK;
 }
 
 int cmd_read_pressure_velocity_vtu(char *cmd) {
 
-	// enter
-	debugprint(stddbg, "Entering cmd_read_pressue_velocity_vtu.\n");
+    // enter
+    debugprint(stddbg, "Entering cmd_read_pressue_velocity_vtu.\n");
 
-	// parse command string for filename
-	char vtufn[MAXPATHLEN];
-	vtufn[0] = '\0';
-	parseCmdStr(cmd, vtufn);
+    // parse command string for filename
+    char vtufn[MAXPATHLEN];
+    vtufn[0] = '\0';
+    parseCmdStr(cmd, vtufn);
 
-	if(read_variables_vtu(vtufn,"pressure","velocity","",false,"",false,"",false)==CV_ERROR){
-		return CV_ERROR;
-	}
+    if(read_variables_vtu(vtufn,"pressure","velocity","",false,"",false,"",false)==CV_ERROR){
+        return CV_ERROR;
+    }
 
-	debugprint(stddbg, "Exiting cmd_read_pressue_velocity_vtu.\n");
-	return CV_OK;
+    debugprint(stddbg, "Exiting cmd_read_pressue_velocity_vtu.\n");
+    return CV_OK;
 }
 
 int cmd_read_pressure_vtu(char *cmd) {
 
-	// enter
-	debugprint(stddbg, "Entering cmd_read_pressure_vtu.\n");
+    // enter
+    debugprint(stddbg, "Entering cmd_read_pressure_vtu.\n");
 
     // parse command string for filename and variable name
     int n = 0;
@@ -1071,22 +1081,22 @@ int cmd_read_pressure_vtu(char *cmd) {
 
     string pres_name="pressure";
     if(vn[0]!='\0'){
-    	pres_name=string(vn);
+        pres_name=string(vn);
     }
 
     // do work
-	if(read_variables_vtu(vtufn,pres_name,"","",false,"",false,"",false)==CV_ERROR){
-		return CV_ERROR;
-	}
+    if(read_variables_vtu(vtufn,pres_name,"","",false,"",false,"",false)==CV_ERROR){
+        return CV_ERROR;
+    }
 
-	debugprint(stddbg, "Exiting cmd_read_pressure_vtu.\n");
-	return CV_OK;
+    debugprint(stddbg, "Exiting cmd_read_pressure_vtu.\n");
+    return CV_OK;
 }
 
 int cmd_read_velocity_vtu(char *cmd) {
 
-	// enter
-	debugprint(stddbg, "Entering cmd_read_velocity_vtu.\n");
+    // enter
+    debugprint(stddbg, "Entering cmd_read_velocity_vtu.\n");
 
     // parse command string for filename and variable name
     int n = 0;
@@ -1103,22 +1113,22 @@ int cmd_read_velocity_vtu(char *cmd) {
 
     string vel_name="velocity";
     if(vn[0]!='\0'){
-    	vel_name=string(vn);
+        vel_name=string(vn);
     }
 
     // do work
-	if(read_variables_vtu(vtufn,"",vel_name,"",false,"",false,"",false)==CV_ERROR){
-		return CV_ERROR;
-	}
+    if(read_variables_vtu(vtufn,"",vel_name,"",false,"",false,"",false)==CV_ERROR){
+        return CV_ERROR;
+    }
 
-	debugprint(stddbg, "Exiting cmd_read_velocity_vtu.\n");
-	return CV_OK;
+    debugprint(stddbg, "Exiting cmd_read_velocity_vtu.\n");
+    return CV_OK;
 }
 
 int cmd_read_displacements_vtu(char *cmd) {
 
-	// enter
-	debugprint(stddbg, "Entering cmd_read_displacements_vtu.\n");
+    // enter
+    debugprint(stddbg, "Entering cmd_read_displacements_vtu.\n");
 
     // parse command string for filename and variable name
     int n = 0;
@@ -1135,22 +1145,22 @@ int cmd_read_displacements_vtu(char *cmd) {
 
     string disp_name="displacement";
     if(vn[0]!='\0'){
-    	disp_name=string(vn);
+        disp_name=string(vn);
     }
 
     // do work
-	if(read_variables_vtu(vtufn,"","",disp_name,true,"",false,"",false)==CV_ERROR){
-		return CV_ERROR;
-	}
+    if(read_variables_vtu(vtufn,"","",disp_name,true,"",false,"",false)==CV_ERROR){
+        return CV_ERROR;
+    }
 
-	debugprint(stddbg, "Exiting cmd_read_displacements_vtu.\n");
-	return CV_OK;
+    debugprint(stddbg, "Exiting cmd_read_displacements_vtu.\n");
+    return CV_OK;
 }
 
 int cmd_read_accelerations_vtu(char *cmd) {
 
-	// enter
-	debugprint(stddbg, "Entering cmd_read_accelerations_vtu.\n");
+    // enter
+    debugprint(stddbg, "Entering cmd_read_accelerations_vtu.\n");
 
     // parse command string for filename and variable name
     int n = 0;
@@ -1167,22 +1177,22 @@ int cmd_read_accelerations_vtu(char *cmd) {
 
     string tD_name="timeDeriv";
     if(vn[0]!='\0'){
-    	tD_name=string(vn);
+        tD_name=string(vn);
     }
 
     // do work
-	if(read_variables_vtu(vtufn,"","","",false,tD_name,true,"",false)==CV_ERROR){
-		return CV_ERROR;
-	}
+    if(read_variables_vtu(vtufn,"","","",false,tD_name,true,"",false)==CV_ERROR){
+        return CV_ERROR;
+    }
 
-	debugprint(stddbg, "Exiting cmd_read_accelerations_vtu.\n");
-	return CV_OK;
+    debugprint(stddbg, "Exiting cmd_read_accelerations_vtu.\n");
+    return CV_OK;
 }
 
 int cmd_read_varwallprop_vtu(char *cmd) {
 
-	// enter
-	debugprint(stddbg, "Entering cmd_read_varwallprop_vtu.\n");
+    // enter
+    debugprint(stddbg, "Entering cmd_read_varwallprop_vtu.\n");
 
     // parse command string for filename and variable name
     int n = 0;
@@ -1199,333 +1209,333 @@ int cmd_read_varwallprop_vtu(char *cmd) {
 
     string wp_name="wallproperty";
     if(vn[0]!='\0'){
-    	wp_name=string(vn);
+        wp_name=string(vn);
     }
 
     // do work
-	if(read_variables_vtu(vtufn,"","","",false,"",false,wp_name,true)==CV_ERROR){
-		return CV_ERROR;
-	}
+    if(read_variables_vtu(vtufn,"","","",false,"",false,wp_name,true)==CV_ERROR){
+        return CV_ERROR;
+    }
 
-	debugprint(stddbg, "Exiting cmd_read_varwallprop_vtu.\n");
-	return CV_OK;
+    debugprint(stddbg, "Exiting cmd_read_varwallprop_vtu.\n");
+    return CV_OK;
 }
 
 int cmd_noslip_vtp(char *cmd) {
 
-	// enter
-	debugprint(stddbg, "Entering cmd_noslip.\n");
+    // enter
+    debugprint(stddbg, "Entering cmd_noslip.\n");
 
-	// do work
+    // do work
 
-	// parse command string for filename
-	char polyfn[MAXPATHLEN];
-	polyfn[0] = '\0';
-	parseCmdStr(cmd, polyfn);
+    // parse command string for filename
+    char polyfn[MAXPATHLEN];
+    polyfn[0] = '\0';
+    parseCmdStr(cmd, polyfn);
 
-	// check file exists
-	FILE* fp = NULL;
-	if ((fp = fopen(polyfn, "r")) == NULL) {
-		fprintf(stderr, "ERROR: could not open file (%s).", polyfn);
-		return CV_ERROR;
-	} else {
-		fclose(fp);
-	}
+    // check file exists
+    FILE* fp = NULL;
+    if ((fp = fopen(polyfn, "r")) == NULL) {
+        fprintf(stderr, "ERROR: could not open file (%s).", polyfn);
+        return CV_ERROR;
+    } else {
+        fclose(fp);
+    }
 
-	// read file
-	vtkPolyData* pd = NULL;
-	vtkXMLPolyDataReader* reader = vtkXMLPolyDataReader::New();
-	reader->SetFileName(polyfn);
-	reader->Update();
-	pd = reader->GetOutput();
-	if (pd == NULL) {
-		fprintf(stderr, "ERROR: problem parsing file (%s).", polyfn);
-		return CV_ERROR;
-	}
-	vtkIntArray* gids = NULL;
-	gids =static_cast<vtkIntArray*>(reader->GetOutput()->GetPointData()->GetArray("GlobalNodeID"));
-	if (gids == NULL) {
-		fprintf(stderr, "ERROR: problem finding GlobalNodeID");
-		return CV_ERROR;
-	}
+    // read file
+    vtkPolyData* pd = NULL;
+    vtkXMLPolyDataReader* reader = vtkXMLPolyDataReader::New();
+    reader->SetFileName(polyfn);
+    reader->Update();
+    pd = reader->GetOutput();
+    if (pd == NULL) {
+        fprintf(stderr, "ERROR: problem parsing file (%s).", polyfn);
+        return CV_ERROR;
+    }
+    vtkIntArray* gids = NULL;
+    gids =static_cast<vtkIntArray*>(reader->GetOutput()->GetPointData()->GetArray("GlobalNodeID"));
+    if (gids == NULL) {
+        fprintf(stderr, "ERROR: problem finding GlobalNodeID");
+        return CV_ERROR;
+    }
 
-	for (int i = 0; i < gids->GetNumberOfTuples(); i++) {
-		int nodeId = gids->GetTuple1(i);
-		debugprint(stddbg, "  BC (%i) Dirichlet BC on Node (%i): %i.\n", i,
-				nodeId, 56);
-		iBC_[nodeId - 1] = 56;
-	}
+    for (int i = 0; i < gids->GetNumberOfTuples(); i++) {
+        int nodeId = gids->GetTuple1(i);
+        debugprint(stddbg, "  BC (%i) Dirichlet BC on Node (%i): %i.\n", i,
+                nodeId, 56);
+        iBC_[nodeId - 1] = 56;
+    }
 
-	// cleanup
-	reader->Delete();
+    // cleanup
+    reader->Delete();
 
-	debugprint(stddbg, "Exiting cmd_noslip.\n");
-	return CV_OK;
+    debugprint(stddbg, "Exiting cmd_noslip.\n");
+    return CV_OK;
 }
 
 int cmd_prescribed_velocities_vtp(char *cmd) {
 
-	// enter
-	debugprint(stddbg, "Entering cmd_prescribed_velocities.\n");
+    // enter
+    debugprint(stddbg, "Entering cmd_prescribed_velocities.\n");
 
-	// do work
+    // do work
 
-	// these are treated the same as noslip in geombc.dat
-	cmd_noslip_vtp(cmd);
+    // these are treated the same as noslip in geombc.dat
+    cmd_noslip_vtp(cmd);
 
-	// cleanup
-	debugprint(stddbg, "Exiting cmd_prescribed_velocities.\n");
-	return CV_OK;
+    // cleanup
+    debugprint(stddbg, "Exiting cmd_prescribed_velocities.\n");
+    return CV_OK;
 }
 
 int setBoundaryFacesWithCodeVTK(char *cmd, int setSurfID, int surfID,
-		int setCode, int code, double value) {
+        int setCode, int code, double value) {
 
-	int i;
+    int i;
 
-	// enter
-	debugprint(stddbg, "Entering setBoundaryFacesWithCodeVTK.\n");
+    // enter
+    debugprint(stddbg, "Entering setBoundaryFacesWithCodeVTK.\n");
 
-	// parse command string for filename
-	char polyfn[MAXPATHLEN];
-	polyfn[0] = '\0';
-	parseCmdStr(cmd, polyfn);
+    // parse command string for filename
+    char polyfn[MAXPATHLEN];
+    polyfn[0] = '\0';
+    parseCmdStr(cmd, polyfn);
 
-	// check file exists
-	FILE* fp = NULL;
-	if ((fp = fopen(polyfn, "r")) == NULL) {
-		fprintf(stderr, "ERROR: could not open file (%s).", polyfn);
-		return CV_ERROR;
-	} else {
-		fclose(fp);
-	}
+    // check file exists
+    FILE* fp = NULL;
+    if ((fp = fopen(polyfn, "r")) == NULL) {
+        fprintf(stderr, "ERROR: could not open file (%s).", polyfn);
+        return CV_ERROR;
+    } else {
+        fclose(fp);
+    }
 
-	// read file
-	vtkPolyData* pd = NULL;
-	vtkXMLPolyDataReader* reader = vtkXMLPolyDataReader::New();
-	reader->SetFileName(polyfn);
-	reader->Update();
-	pd = reader->GetOutput();
-	if (pd == NULL) {
-		fprintf(stderr, "ERROR: problem parsing file (%s).", polyfn);
-		return CV_ERROR;
-	}
+    // read file
+    vtkPolyData* pd = NULL;
+    vtkXMLPolyDataReader* reader = vtkXMLPolyDataReader::New();
+    reader->SetFileName(polyfn);
+    reader->Update();
+    pd = reader->GetOutput();
+    if (pd == NULL) {
+        fprintf(stderr, "ERROR: problem parsing file (%s).", polyfn);
+        return CV_ERROR;
+    }
 
-	pd->GetPointData()->SetActiveScalars("GlobalNodeID");
-	pd->GetCellData()->SetActiveScalars("GlobalElementID");
+    pd->GetPointData()->SetActiveScalars("GlobalNodeID");
+    pd->GetCellData()->SetActiveScalars("GlobalElementID");
 
-	vtkIdList* ptids = vtkIdList::New();
-	ptids->Allocate(10, 10);
-	ptids->Initialize();
+    vtkIdList* ptids = vtkIdList::New();
+    ptids->Allocate(10, 10);
+    ptids->Initialize();
 
-	vtkCellArray *cells = pd->GetPolys();
-	cells->InitTraversal();
+    vtkCellArray *cells = pd->GetPolys();
+    cells->InitTraversal();
 
-	vtkIntArray* gids = NULL;
-	gids = static_cast<vtkIntArray*>(pd->GetPointData()->GetArray(
-			"GlobalNodeID"));
-	if (gids == NULL) {
-		fprintf(stderr, "ERROR: problem finding GlobalNodeID");
-		return CV_ERROR;
-	}
+    vtkIntArray* gids = NULL;
+    gids = static_cast<vtkIntArray*>(pd->GetPointData()->GetArray(
+            "GlobalNodeID"));
+    if (gids == NULL) {
+        fprintf(stderr, "ERROR: problem finding GlobalNodeID");
+        return CV_ERROR;
+    }
 
-	// Loop on vtp faces
-	int n0, n1, n2, n3;
-	int elementId;
-	int totCodeFaces = 0;
-	int totSurfIDFaces = 0;
-	for (int icell = 0; icell < cells->GetNumberOfCells(); icell++) {
+    // Loop on vtp faces
+    int n0, n1, n2, n3;
+    int elementId;
+    int totCodeFaces = 0;
+    int totSurfIDFaces = 0;
+    for (int icell = 0; icell < cells->GetNumberOfCells(); icell++) {
 
-		ptids->Reset();
-		cells->GetCell(4 * icell, ptids);
-		if (ptids->GetNumberOfIds() != 3) {
-			fprintf(stderr, "ERROR:  invalid number of ids in cell (%i)!",
-					ptids->GetNumberOfIds());
-			return CV_ERROR;
-		}
-		elementId = pd->GetCellData()->GetScalars()->GetTuple1(icell);
-		n0 = gids->GetTuple1(ptids->GetId(0));
-		n1 = gids->GetTuple1(ptids->GetId(1));
-		n2 = gids->GetTuple1(ptids->GetId(2));
-		n3 = -1;
+        ptids->Reset();
+        cells->GetCell(4 * icell, ptids);
+        if (ptids->GetNumberOfIds() != 3) {
+            fprintf(stderr, "ERROR:  invalid number of ids in cell (%i)!",
+                    ptids->GetNumberOfIds());
+            return CV_ERROR;
+        }
+        elementId = pd->GetCellData()->GetScalars()->GetTuple1(icell);
+        n0 = gids->GetTuple1(ptids->GetId(0));
+        n1 = gids->GetTuple1(ptids->GetId(1));
+        n2 = gids->GetTuple1(ptids->GetId(2));
+        n3 = -1;
 
-		int j0 = n0;
-		int j1 = n1;
-		int j2 = n2;
-		int j3 = -1;
+        int j0 = n0;
+        int j1 = n1;
+        int j2 = n2;
+        int j3 = -1;
 
-		for (i = 0; i < 4; i++) {
-			if (elements_[i * numElements_ + (elementId - 1)] != j0
-					&& elements_[i * numElements_ + (elementId - 1)] != j1
-					&& elements_[i * numElements_ + (elementId - 1)] != j2) {
-				j3 = elements_[i * numElements_ + (elementId - 1)];
-				break;
-			}
-		}
+        for (i = 0; i < 4; i++) {
+            if (elements_[i * numElements_ + (elementId - 1)] != j0
+                    && elements_[i * numElements_ + (elementId - 1)] != j1
+                    && elements_[i * numElements_ + (elementId - 1)] != j2) {
+                j3 = elements_[i * numElements_ + (elementId - 1)];
+                break;
+            }
+        }
 
-		if (j3 < 0) {
-			fprintf(stderr,
-					"ERROR:  could not find nodes in element (%i %i %i %i)\n",
-					elementId, n0, n1, n2);
-			return CV_ERROR;
-		}
+        if (j3 < 0) {
+            fprintf(stderr,
+                    "ERROR:  could not find nodes in element (%i %i %i %i)\n",
+                    elementId, n0, n1, n2);
+            return CV_ERROR;
+        }
 
-		double a[3];
-		double b[3];
-		double c[3];
-		double norm0, norm1, norm2;
+        double a[3];
+        double b[3];
+        double c[3];
+        double norm0, norm1, norm2;
 
-		a[0] = nodes_[0 * numNodes_ + j1 - 1] - nodes_[0 * numNodes_ + j0 - 1];
-		a[1] = nodes_[1 * numNodes_ + j1 - 1] - nodes_[1 * numNodes_ + j0 - 1];
-		a[2] = nodes_[2 * numNodes_ + j1 - 1] - nodes_[2 * numNodes_ + j0 - 1];
-		b[0] = nodes_[0 * numNodes_ + j2 - 1] - nodes_[0 * numNodes_ + j0 - 1];
-		b[1] = nodes_[1 * numNodes_ + j2 - 1] - nodes_[1 * numNodes_ + j0 - 1];
-		b[2] = nodes_[2 * numNodes_ + j2 - 1] - nodes_[2 * numNodes_ + j0 - 1];
-		c[0] = nodes_[0 * numNodes_ + j3 - 1] - nodes_[0 * numNodes_ + j0 - 1];
-		c[1] = nodes_[1 * numNodes_ + j3 - 1] - nodes_[1 * numNodes_ + j0 - 1];
-		c[2] = nodes_[2 * numNodes_ + j3 - 1] - nodes_[2 * numNodes_ + j0 - 1];
+        a[0] = nodes_[0 * numNodes_ + j1 - 1] - nodes_[0 * numNodes_ + j0 - 1];
+        a[1] = nodes_[1 * numNodes_ + j1 - 1] - nodes_[1 * numNodes_ + j0 - 1];
+        a[2] = nodes_[2 * numNodes_ + j1 - 1] - nodes_[2 * numNodes_ + j0 - 1];
+        b[0] = nodes_[0 * numNodes_ + j2 - 1] - nodes_[0 * numNodes_ + j0 - 1];
+        b[1] = nodes_[1 * numNodes_ + j2 - 1] - nodes_[1 * numNodes_ + j0 - 1];
+        b[2] = nodes_[2 * numNodes_ + j2 - 1] - nodes_[2 * numNodes_ + j0 - 1];
+        c[0] = nodes_[0 * numNodes_ + j3 - 1] - nodes_[0 * numNodes_ + j0 - 1];
+        c[1] = nodes_[1 * numNodes_ + j3 - 1] - nodes_[1 * numNodes_ + j0 - 1];
+        c[2] = nodes_[2 * numNodes_ + j3 - 1] - nodes_[2 * numNodes_ + j0 - 1];
 
-		Cross(a[0], a[1], a[2], b[0], b[1], b[2], &norm0, &norm1, &norm2);
-		double mydot = Dot(norm0, norm1, norm2, c[0], c[1], c[2]);
+        Cross(a[0], a[1], a[2], b[0], b[1], b[2], &norm0, &norm1, &norm2);
+        double mydot = Dot(norm0, norm1, norm2, c[0], c[1], c[2]);
 
-		if (mydot > 0) {
-			int tmpj = j0;
-			j0 = j2;
-			j2 = j1;
-			j1 = tmpj;
-			debugprint(stddbg, "elementId %i : %i %i %i %i   (flipped0) %lf\n",
-					elementId, j0, j1, j2, j3, mydot);
-		} else {
-			debugprint(stddbg, "elementId %i : %i %i %i %i  %lf\n", elementId,
-					j0, j1, j2, j3, mydot);
-		}
+        if (mydot > 0) {
+            int tmpj = j0;
+            j0 = j2;
+            j2 = j1;
+            j1 = tmpj;
+            debugprint(stddbg, "elementId %i : %i %i %i %i   (flipped0) %lf\n",
+                    elementId, j0, j1, j2, j3, mydot);
+        } else {
+            debugprint(stddbg, "elementId %i : %i %i %i %i  %lf\n", elementId,
+                    j0, j1, j2, j3, mydot);
+        }
 
-		// find matching element already read in
-		int foundIt = 0;
-		for (i = 0; i < numBoundaryFaces_; i++) {
-			// Check Global Element Number
-			if (boundaryElementsIds_[i] == (elementId - 1)) {
-				// Check if the fourth node corresponds
-				if (boundaryElements_[3][i] == j3) {
-					// Set Code
-					if (setCode) {
-						iBCB_[i] = code;
-						BCB_[1 * numBoundaryFaces_ + i] = value;
-						foundIt = 1;
-						totCodeFaces++;
-					}
-					// Set Surface Number
-					if (setSurfID) {
-						iBCB_[numBoundaryFaces_ + i] = surfID;
-						foundIt = 1;
-						totSurfIDFaces++;
-					}
-				}
-			}
-		}
+        // find matching element already read in
+        int foundIt = 0;
+        for (i = 0; i < numBoundaryFaces_; i++) {
+            // Check Global Element Number
+            if (boundaryElementsIds_[i] == (elementId - 1)) {
+                // Check if the fourth node corresponds
+                if (boundaryElements_[3][i] == j3) {
+                    // Set Code
+                    if (setCode) {
+                        iBCB_[i] = code;
+                        BCB_[1 * numBoundaryFaces_ + i] = value;
+                        foundIt = 1;
+                        totCodeFaces++;
+                    }
+                    // Set Surface Number
+                    if (setSurfID) {
+                        iBCB_[numBoundaryFaces_ + i] = surfID;
+                        foundIt = 1;
+                        totSurfIDFaces++;
+                    }
+                }
+            }
+        }
 
-		if (foundIt == 0) {
-			fprintf(stderr,
-					"ERROR: could not find pressure face in boundary faces!\n");
-			return CV_ERROR;
-		}
+        if (foundIt == 0) {
+            fprintf(stderr,
+                    "ERROR: could not find pressure face in boundary faces!\n");
+            return CV_ERROR;
+        }
 
-	}
+    }
 
-	// Write Debug Message to Make Sure the number of Surfaces is Correct
-	debugprint(stddbg, "Assigned %d Codes and %d surfIDs\n", totCodeFaces,
-			totSurfIDFaces);
+    // Write Debug Message to Make Sure the number of Surfaces is Correct
+    debugprint(stddbg, "Assigned %d Codes and %d surfIDs\n", totCodeFaces,
+            totSurfIDFaces);
 
-	// cleanup
-	ptids->Delete();
-	reader->Delete();
+    // cleanup
+    ptids->Delete();
+    reader->Delete();
 
-	debugprint(stddbg, "Exiting setBoundaryFacesWithCodeVTK.\n");
-	return CV_OK;
+    debugprint(stddbg, "Exiting setBoundaryFacesWithCodeVTK.\n");
+    return CV_OK;
 
 }
 
 int cmd_zero_pressure_vtp(char *cmd) {
 
-	// enter
-	debugprint(stddbg, "Entering cmd_zero_pressure.\n");
+    // enter
+    debugprint(stddbg, "Entering cmd_zero_pressure.\n");
 
-	// do work
-	double pressure = 0.0;
-	int setSurfID = 0;
-	int surfID = 0;
-	int setPressure = 1;
+    // do work
+    double pressure = 0.0;
+    int setSurfID = 0;
+    int surfID = 0;
+    int setPressure = 1;
 
-	// should use bits and not ints here!!
-	int code = 2;
+    // should use bits and not ints here!!
+    int code = 2;
 
-	if (setBoundaryFacesWithCodeVTK(cmd, setSurfID, surfID, setPressure, code,
-			pressure) == CV_ERROR) {
-		return CV_ERROR;
-	}
+    if (setBoundaryFacesWithCodeVTK(cmd, setSurfID, surfID, setPressure, code,
+            pressure) == CV_ERROR) {
+        return CV_ERROR;
+    }
 
-	// cleanup
-	debugprint(stddbg, "Exiting cmd_zero_pressure.\n");
-	return CV_OK;
+    // cleanup
+    debugprint(stddbg, "Exiting cmd_zero_pressure.\n");
+    return CV_OK;
 }
 
 int cmd_pressure_vtp(char *cmd) {
 
-	// enter
-	debugprint(stddbg, "Entering cmd_pressure.\n");
+    // enter
+    debugprint(stddbg, "Entering cmd_pressure.\n");
 
-	// do work
-	double pressure = 0.0;
+    // do work
+    double pressure = 0.0;
 
-	if (parseDouble2(cmd, &pressure) == CV_ERROR) {
-		return CV_ERROR;
-	}
+    if (parseDouble2(cmd, &pressure) == CV_ERROR) {
+        return CV_ERROR;
+    }
 
-	debugprint(stddbg, "  Pressure = %lf\n", pressure);
+    debugprint(stddbg, "  Pressure = %lf\n", pressure);
 
-	int setSurfID = 0;
-	int surfID = 0;
-	int setPressure = 1;
-	// should use bits and not ints here!!
-	int code = 2;
+    int setSurfID = 0;
+    int surfID = 0;
+    int setPressure = 1;
+    // should use bits and not ints here!!
+    int code = 2;
 
-	if (setBoundaryFacesWithCodeVTK(cmd, setSurfID, surfID, setPressure, code,
-			pressure) == CV_ERROR) {
-		return CV_ERROR;
-	}
+    if (setBoundaryFacesWithCodeVTK(cmd, setSurfID, surfID, setPressure, code,
+            pressure) == CV_ERROR) {
+        return CV_ERROR;
+    }
 
-	// cleanup
-	debugprint(stddbg, "Exiting cmd_pressure.\n");
-	return CV_OK;
+    // cleanup
+    debugprint(stddbg, "Exiting cmd_pressure.\n");
+    return CV_OK;
 }
 
 int cmd_set_surface_id_vtp(char *cmd) {
 
-	// enter
-	debugprint(stddbg, "Entering cmd_set_surface_id.\n");
+    // enter
+    debugprint(stddbg, "Entering cmd_set_surface_id.\n");
 
-	// do work
-	int surfID = 0;
-	if (parseNum2(cmd, &surfID) == CV_ERROR) {
-		return CV_ERROR;
-	}
+    // do work
+    int surfID = 0;
+    if (parseNum2(cmd, &surfID) == CV_ERROR) {
+        return CV_ERROR;
+    }
 
-	debugprint(stddbg, "  Setting surfID to [%i]\n", surfID);
+    debugprint(stddbg, "  Setting surfID to [%i]\n", surfID);
 
-	double value = 0.0;
-	int setSurfID = 1;
-	int setCode = 0;
-	// should use bits and not ints here!!
-	int code = 0;
+    double value = 0.0;
+    int setSurfID = 1;
+    int setCode = 0;
+    // should use bits and not ints here!!
+    int code = 0;
 
-	if (setBoundaryFacesWithCodeVTK(cmd, setSurfID, surfID, setCode, code,
-			value) == CV_ERROR) {
-		return CV_ERROR;
-	}
+    if (setBoundaryFacesWithCodeVTK(cmd, setSurfID, surfID, setCode, code,
+            value) == CV_ERROR) {
+        return CV_ERROR;
+    }
 
-	// cleanup
-	debugprint(stddbg, "Exiting cmd_set_surface_id.\n");
-	return CV_OK;
+    // cleanup
+    debugprint(stddbg, "Exiting cmd_set_surface_id.\n");
+    return CV_OK;
 }
 
 
@@ -1771,48 +1781,48 @@ int cmd_create_mesh_deformable_vtp(char *cmd) {
 
     int i,j;
 
-	// parse command string for filename
-	char polyfn[MAXPATHLEN];
-	polyfn[0] = '\0';
-	parseCmdStr(cmd, polyfn);
+    // parse command string for filename
+    char polyfn[MAXPATHLEN];
+    polyfn[0] = '\0';
+    parseCmdStr(cmd, polyfn);
 
-	// check file exists
-	FILE* fp = NULL;
-	if ((fp = fopen(polyfn, "r")) == NULL) {
-		fprintf(stderr, "ERROR: could not open file (%s).", polyfn);
-		return CV_ERROR;
-	} else {
-		fclose(fp);
-	}
+    // check file exists
+    FILE* fp = NULL;
+    if ((fp = fopen(polyfn, "r")) == NULL) {
+        fprintf(stderr, "ERROR: could not open file (%s).", polyfn);
+        return CV_ERROR;
+    } else {
+        fclose(fp);
+    }
 
-	// read file
-	vtkPolyData* pd = NULL;
-	vtkXMLPolyDataReader* reader = vtkXMLPolyDataReader::New();
-	reader->SetFileName(polyfn);
-	reader->Update();
-	pd = reader->GetOutput();
-	if (pd == NULL) {
-		fprintf(stderr, "ERROR: problem parsing file (%s).", polyfn);
-		return CV_ERROR;
-	}
+    // read file
+    vtkPolyData* pd = NULL;
+    vtkXMLPolyDataReader* reader = vtkXMLPolyDataReader::New();
+    reader->SetFileName(polyfn);
+    reader->Update();
+    pd = reader->GetOutput();
+    if (pd == NULL) {
+        fprintf(stderr, "ERROR: problem parsing file (%s).", polyfn);
+        return CV_ERROR;
+    }
 
-	pd->GetPointData()->SetActiveScalars("GlobalNodeID");
-	pd->GetCellData()->SetActiveScalars("GlobalElementID");
+    pd->GetPointData()->SetActiveScalars("GlobalNodeID");
+    pd->GetCellData()->SetActiveScalars("GlobalElementID");
 
-	vtkIdList* ptids = vtkIdList::New();
-	ptids->Allocate(10, 10);
-	ptids->Initialize();
+    vtkIdList* ptids = vtkIdList::New();
+    ptids->Allocate(10, 10);
+    ptids->Initialize();
 
-	vtkCellArray *cells = pd->GetPolys();
-	cells->InitTraversal();
+    vtkCellArray *cells = pd->GetPolys();
+    cells->InitTraversal();
 
-	vtkIntArray* gids = NULL;
-	gids = static_cast<vtkIntArray*>(pd->GetPointData()->GetArray(
-			"GlobalNodeID"));
-	if (gids == NULL) {
-		fprintf(stderr, "ERROR: problem finding GlobalNodeID");
-		return CV_ERROR;
-	}
+    vtkIntArray* gids = NULL;
+    gids = static_cast<vtkIntArray*>(pd->GetPointData()->GetArray(
+            "GlobalNodeID"));
+    if (gids == NULL) {
+        fprintf(stderr, "ERROR: problem finding GlobalNodeID");
+        return CV_ERROR;
+    }
 
     int numEle = cells->GetNumberOfCells();
     if (numEle == 0) {
@@ -1829,19 +1839,19 @@ int cmd_create_mesh_deformable_vtp(char *cmd) {
     int numIds = 0;
     int numElements = 0;
 
-	for (int icell = 0; icell < cells->GetNumberOfCells(); icell++) {
+    for (int icell = 0; icell < cells->GetNumberOfCells(); icell++) {
 
-		ptids->Reset();
-		cells->GetCell(4 * icell, ptids);
-		if (ptids->GetNumberOfIds() != 3) {
-			fprintf(stderr, "ERROR:  invalid number of ids in cell (%i)!",
-					ptids->GetNumberOfIds());
-			return CV_ERROR;
-		}
-		elementId = pd->GetCellData()->GetScalars()->GetTuple1(icell);
-		n0 = gids->GetTuple1(ptids->GetId(0));
-		n1 = gids->GetTuple1(ptids->GetId(1));
-		n2 = gids->GetTuple1(ptids->GetId(2));
+        ptids->Reset();
+        cells->GetCell(4 * icell, ptids);
+        if (ptids->GetNumberOfIds() != 3) {
+            fprintf(stderr, "ERROR:  invalid number of ids in cell (%i)!",
+                    ptids->GetNumberOfIds());
+            return CV_ERROR;
+        }
+        elementId = pd->GetCellData()->GetScalars()->GetTuple1(icell);
+        n0 = gids->GetTuple1(ptids->GetId(0));
+        n1 = gids->GetTuple1(ptids->GetId(1));
+        n2 = gids->GetTuple1(ptids->GetId(2));
 
         ids[0][numIds] = n0;
         ids[1][numIds] = numElements;
@@ -1958,9 +1968,9 @@ int cmd_create_mesh_deformable_vtp(char *cmd) {
     DisplacementNumNodes_    = numUniqueNodes;
     DisplacementNodeMap_     = map;
 
-	// cleanup
-	ptids->Delete();
-	reader->Delete();
+    // cleanup
+    ptids->Delete();
+    reader->Delete();
 
     debugprint(stddbg,"Exiting cmd_create_mesh_deformable_vtp.\n");
     return CV_OK;
@@ -2122,36 +2132,36 @@ int cmd_set_scalar_BCs_vtp(char *cmd) {
 
     debugprint(stddbg,"Setting surface thickness or Evw to [%lf] \n",value);
 
-	// parse command string for filename
-	char polyfn[MAXPATHLEN];
-	polyfn[0] = '\0';
-	parseCmdStr(cmd, polyfn);
+    // parse command string for filename
+    char polyfn[MAXPATHLEN];
+    polyfn[0] = '\0';
+    parseCmdStr(cmd, polyfn);
 
-	// check file exists
-	FILE* fp = NULL;
-	if ((fp = fopen(polyfn, "r")) == NULL) {
-		fprintf(stderr, "ERROR: could not open file (%s).", polyfn);
-		return CV_ERROR;
-	} else {
-		fclose(fp);
-	}
+    // check file exists
+    FILE* fp = NULL;
+    if ((fp = fopen(polyfn, "r")) == NULL) {
+        fprintf(stderr, "ERROR: could not open file (%s).", polyfn);
+        return CV_ERROR;
+    } else {
+        fclose(fp);
+    }
 
-	// read file
-	vtkPolyData* pd = NULL;
-	vtkXMLPolyDataReader* reader = vtkXMLPolyDataReader::New();
-	reader->SetFileName(polyfn);
-	reader->Update();
-	pd = reader->GetOutput();
-	if (pd == NULL) {
-		fprintf(stderr, "ERROR: problem parsing file (%s).", polyfn);
-		return CV_ERROR;
-	}
-	vtkIntArray* gids = NULL;
-	gids =static_cast<vtkIntArray*>(reader->GetOutput()->GetPointData()->GetArray("GlobalNodeID"));
-	if (gids == NULL) {
-		fprintf(stderr, "ERROR: problem finding GlobalNodeID");
-		return CV_ERROR;
-	}
+    // read file
+    vtkPolyData* pd = NULL;
+    vtkXMLPolyDataReader* reader = vtkXMLPolyDataReader::New();
+    reader->SetFileName(polyfn);
+    reader->Update();
+    pd = reader->GetOutput();
+    if (pd == NULL) {
+        fprintf(stderr, "ERROR: problem parsing file (%s).", polyfn);
+        return CV_ERROR;
+    }
+    vtkIntArray* gids = NULL;
+    gids =static_cast<vtkIntArray*>(reader->GetOutput()->GetPointData()->GetArray("GlobalNodeID"));
+    if (gids == NULL) {
+        fprintf(stderr, "ERROR: problem finding GlobalNodeID");
+        return CV_ERROR;
+    }
 
     if (gBC_ == NULL) {
      gBC_ = new double [numNodes_];
@@ -2160,13 +2170,13 @@ int cmd_set_scalar_BCs_vtp(char *cmd) {
      }
     }
 
-	for (int i = 0; i < gids->GetNumberOfTuples(); i++) {
-		int nodeId = gids->GetTuple1(i);
-		gBC_[nodeId - 1] = value;
-	}
+    for (int i = 0; i < gids->GetNumberOfTuples(); i++) {
+        int nodeId = gids->GetTuple1(i);
+        gBC_[nodeId - 1] = value;
+    }
 
-	// cleanup
-	reader->Delete();
+    // cleanup
+    reader->Delete();
 
     // cleanup
     debugprint(stddbg,"Exiting cmd_set_scalar_BCs_vtp.\n");
@@ -2186,17 +2196,17 @@ int cmd_set_Evw_BCs_vtp(char *cmd){
 
 // SET SPRING CONSTANT BC
 int cmd_set_ksvw_BCs_vtp(char *cmd){
-	return cmd_set_scalar_BCs_vtp(cmd);
+    return cmd_set_scalar_BCs_vtp(cmd);
 }
 
 // SET DAMPING CONSTANT BC
 int cmd_set_csvw_BCs_vtp(char *cmd){
-	return cmd_set_scalar_BCs_vtp(cmd);
+    return cmd_set_scalar_BCs_vtp(cmd);
 }
 
 // SET_EXTERNAL PRESSURE BC
 int cmd_set_p0vw_BCs_vtp(char *cmd){
-	return cmd_set_scalar_BCs_vtp(cmd);
+    return cmd_set_scalar_BCs_vtp(cmd);
 }
 
 
@@ -2213,36 +2223,36 @@ int cmd_set_Initial_Evw_vtp(char *cmd) {
 
     debugprint(stddbg,"Setting initial value to [%lf] \n",value);
 
-	// parse command string for filename
-	char polyfn[MAXPATHLEN];
-	polyfn[0] = '\0';
-	parseCmdStr(cmd, polyfn);
+    // parse command string for filename
+    char polyfn[MAXPATHLEN];
+    polyfn[0] = '\0';
+    parseCmdStr(cmd, polyfn);
 
-	// check file exists
-	FILE* fp = NULL;
-	if ((fp = fopen(polyfn, "r")) == NULL) {
-		fprintf(stderr, "ERROR: could not open file (%s).", polyfn);
-		return CV_ERROR;
-	} else {
-		fclose(fp);
-	}
+    // check file exists
+    FILE* fp = NULL;
+    if ((fp = fopen(polyfn, "r")) == NULL) {
+        fprintf(stderr, "ERROR: could not open file (%s).", polyfn);
+        return CV_ERROR;
+    } else {
+        fclose(fp);
+    }
 
-	// read file
-	vtkPolyData* pd = NULL;
-	vtkXMLPolyDataReader* reader = vtkXMLPolyDataReader::New();
-	reader->SetFileName(polyfn);
-	reader->Update();
-	pd = reader->GetOutput();
-	if (pd == NULL) {
-		fprintf(stderr, "ERROR: problem parsing file (%s).", polyfn);
-		return CV_ERROR;
-	}
-	vtkIntArray* gids = NULL;
-	gids =static_cast<vtkIntArray*>(reader->GetOutput()->GetPointData()->GetArray("GlobalNodeID"));
-	if (gids == NULL) {
-		fprintf(stderr, "ERROR: problem finding GlobalNodeID");
-		return CV_ERROR;
-	}
+    // read file
+    vtkPolyData* pd = NULL;
+    vtkXMLPolyDataReader* reader = vtkXMLPolyDataReader::New();
+    reader->SetFileName(polyfn);
+    reader->Update();
+    pd = reader->GetOutput();
+    if (pd == NULL) {
+        fprintf(stderr, "ERROR: problem parsing file (%s).", polyfn);
+        return CV_ERROR;
+    }
+    vtkIntArray* gids = NULL;
+    gids =static_cast<vtkIntArray*>(reader->GetOutput()->GetPointData()->GetArray("GlobalNodeID"));
+    if (gids == NULL) {
+        fprintf(stderr, "ERROR: problem finding GlobalNodeID");
+        return CV_ERROR;
+    }
 
     if (gBC_ == NULL) {
      gBC_ = new double [numNodes_];
@@ -2258,13 +2268,13 @@ int cmd_set_Initial_Evw_vtp(char *cmd) {
      }
     }
 
-	for (int i = 0; i < gids->GetNumberOfTuples(); i++) {
-		int nodeId = gids->GetTuple1(i);
-		EvwSolution_[nodeId - 1] = value;
-	}
+    for (int i = 0; i < gids->GetNumberOfTuples(); i++) {
+        int nodeId = gids->GetTuple1(i);
+        EvwSolution_[nodeId - 1] = value;
+    }
 
-	// cleanup
-	reader->Delete();
+    // cleanup
+    reader->Delete();
 
     // cleanup
     debugprint(stddbg,"Exiting cmd_set_Initial_Evw_vtp.\n");
@@ -2327,50 +2337,53 @@ int cmd_varwallprop_write_vtp(char *cmd) {
     }
 
     // /* EXTERNAL TISSUE SUPPORT - ISL JULY 2019 */
-    if (KsvwSolution_ != NULL) {
-    	vtkDoubleArray *ksvw = vtkDoubleArray::New();
-        ksvw->SetNumberOfComponents(1);
-        ksvw->Allocate(numNodes_,10000);
-        ksvw->SetNumberOfTuples(numNodes_);
-        ksvw->SetName("SpringConstant");
-        for(i = 0; i < numNodes_; i++){
-            ksvw->SetTuple1(i,KsvwSolution_[i]);
+    if (itissuesuppt) {
+        if (KsvwSolution_ != NULL) {
+            vtkDoubleArray *ksvw = vtkDoubleArray::New();
+            ksvw->SetNumberOfComponents(1);
+            ksvw->Allocate(numNodes_,10000);
+            ksvw->SetNumberOfTuples(numNodes_);
+            ksvw->SetName("SpringConstant");
+            for(i = 0; i < numNodes_; i++){
+                ksvw->SetTuple1(i,KsvwSolution_[i]);
+            }
+
+            grid->GetPointData()->AddArray(ksvw);
+
+            ksvw->Delete();
         }
 
-        grid->GetPointData()->AddArray(ksvw);
+        if (CsvwSolution_ != NULL) {
+            vtkDoubleArray *csvw = vtkDoubleArray::New();
+            csvw->SetNumberOfComponents(1);
+            csvw->Allocate(numNodes_,10000);
+            csvw->SetNumberOfTuples(numNodes_);
+            csvw->SetName("DampingConstant");
+            for(i = 0; i < numNodes_; i++){
+                csvw->SetTuple1(i,CsvwSolution_[i]);
+            }
 
-        ksvw->Delete();
-    }
+            grid->GetPointData()->AddArray(csvw);
 
-    if (CsvwSolution_ != NULL) {
-    	vtkDoubleArray *csvw = vtkDoubleArray::New();
-        csvw->SetNumberOfComponents(1);
-        csvw->Allocate(numNodes_,10000);
-        csvw->SetNumberOfTuples(numNodes_);
-        csvw->SetName("DampingConstant");
-        for(i = 0; i < numNodes_; i++){
-            csvw->SetTuple1(i,CsvwSolution_[i]);
+            csvw->Delete();
         }
 
-        grid->GetPointData()->AddArray(csvw);
+        if (P0vwSolution_ != NULL) {
+            vtkDoubleArray *p0vw = vtkDoubleArray::New();
+            p0vw->SetNumberOfComponents(1);
+            p0vw->Allocate(numNodes_,10000);
+            p0vw->SetNumberOfTuples(numNodes_);
+            p0vw->SetName("ExternalPressure");
+            for(i = 0; i < numNodes_; i++){
+                p0vw->SetTuple1(i,P0vwSolution_[i]);
+            }
 
-        csvw->Delete();
-    }
+            grid->GetPointData()->AddArray(p0vw);
 
-    if (P0vwSolution_ != NULL) {
-    	vtkDoubleArray *p0vw = vtkDoubleArray::New();
-        p0vw->SetNumberOfComponents(1);
-        p0vw->Allocate(numNodes_,10000);
-        p0vw->SetNumberOfTuples(numNodes_);
-        p0vw->SetName("ExternalPressure");
-        for(i = 0; i < numNodes_; i++){
-            p0vw->SetTuple1(i,P0vwSolution_[i]);
+            p0vw->Delete();
         }
-
-        grid->GetPointData()->AddArray(p0vw);
-
-        p0vw->Delete();
     }
+    
     /* --------------------------------------------------- */
 
 

--- a/Code/FlowSolvers/ThreeDSolver/svPre/supre-cmds.cxx
+++ b/Code/FlowSolvers/ThreeDSolver/svPre/supre-cmds.cxx
@@ -126,10 +126,11 @@ extern double init_p_;
 extern double init_v_[3];
 extern double* soln_;
 extern double* dispsoln_;
+
 #if(VER_VARWALL == 1)
-//variable wall thickness and Young Mod
+//variable wall thickness, Young Mod, external tissue support parameters
 extern double* wallpropsoln_;
-//dirichlet BC for nodes, Laplace Eqn for wallthickness
+//dirichlet BC for nodes, Laplace Eqn for wallthickness,
 extern double* gBC_;
 #endif
 
@@ -140,9 +141,16 @@ extern int*  DisplacementConn_[3];
 extern int   DisplacementNumNodes_;
 extern int*  DisplacementNodeMap_;
 extern double* DisplacementSolution_;
+
 #if(VER_VARWALL == 1)
+extern double* WallPropSolution_;
 extern double* ThicknessSolution_;
 extern double* EvwSolution_;
+extern double* KsvwSolution_;
+extern double* CsvwSolution_;
+extern double* P0vwSolution_;
+
+
 #endif
 extern double  Displacement_Evw_;
 extern double  Displacement_nuvw_;
@@ -979,14 +987,32 @@ int cmd_deformable_solve_var_prop(char *cmd,int use_direct_solve) {
 
 }
 
+
 // SET THICKNESS BC
 int cmd_set_thickness_BCs(char *cmd){
-  return cmd_set_scalar_BCs(cmd);
+    return cmd_set_scalar_BCs(cmd);
 }
+
 
 // SET ELASTIC MODULUS BC
 int cmd_set_Evw_BCs(char *cmd){
-  return cmd_set_scalar_BCs(cmd);
+    return cmd_set_scalar_BCs(cmd);
+}
+
+
+// SET TISSUE SUPPORT SPRING CONSTANT BC
+int cmd_set_ksvw_BCs(char *cmd){
+    return cmd_set_scalar_BCs(cmd);
+}
+
+// SET TISSUE SUPPORT DAMPING CONSTANT BC
+int cmd_set_csvw_BCs(char *cmd){
+    return cmd_set_scalar_BCs(cmd);
+}
+
+// SET TISSUE SUPPORT EXTERNAL PRESSURE BC
+int cmd_set_p0vw_BCs(char *cmd){
+    return cmd_set_scalar_BCs(cmd);
 }
 
 int cmd_set_scalar_BCs(char *cmd) {
@@ -1000,7 +1026,7 @@ int cmd_set_scalar_BCs(char *cmd) {
         return CV_ERROR;
     }
 
-    debugprint(stddbg,"Setting surface thickness or Evw to [%lf] \n",value);
+    debugprint(stddbg,"Setting surface thickness/Evw/ksvw/csvw/p0vw to [%lf] \n",value);
 
     if (parseFile(cmd) == CV_ERROR) {
         return CV_ERROR;
@@ -1033,7 +1059,7 @@ int cmd_set_scalar_BCs(char *cmd) {
     return CV_OK;
 }
 
-int calcThicknessEvwDistribution(int Laplacetype);
+int calcWallPropDistribution(int Laplacetype);
 //int openmptest();
 
 // SOLVE LAPLACE EQUATION WITH THICKNESS
@@ -1043,11 +1069,11 @@ int cmd_Laplace_Thickness(char *cmd) {
     debugprint(stddbg,"Entering cmd_Laplace_Thickness.\n");
 
     if (ThicknessSolution_ == NULL) {
-      ThicknessSolution_ = new double [numNodes_];
+        WallPropSolution_ = new double [numNodes_];
     }
 
     int Laplacetype  = 0; // THICKNESS
-    calcThicknessEvwDistribution(Laplacetype);
+    calcWallPropDistribution(Laplacetype);
 
     // cleanup
     debugprint(stddbg,"Exiting cmd_Laplace_Thickness.\n");
@@ -1061,16 +1087,72 @@ int cmd_Laplace_Evw(char *cmd) {
     debugprint(stddbg,"Entering cmd_Laplace_Evw.\n");
 
     if (EvwSolution_ == NULL) {
-      EvwSolution_ = new double [numNodes_];
+        WallPropSolution_ = new double [numNodes_];
     }
 
     int Laplacetype  = 1; // EVW
-    calcThicknessEvwDistribution(Laplacetype);
+    calcWallPropDistribution(Laplacetype);
 
     // cleanup
     debugprint(stddbg,"Exiting cmd_Laplace_Evw.\n");
     return CV_OK;
 }
+
+
+// SOLVE LAPLACE EQUATION WITH KSVW
+int cmd_Laplace_Ksvw(char *cmd) {
+
+    // enter
+    debugprint(stddbg,"Entering cmd_Laplace_Ksvw.\n");
+
+    if (KsvwSolution_ == NULL) {
+      WallPropSolution_ = new double [numNodes_];
+    }
+
+    int Laplacetype  = 2; // KSVW
+    calcWallPropDistribution(Laplacetype);
+
+    // cleanup
+    debugprint(stddbg,"Exiting cmd_Laplace_Ksvw.\n");
+    return CV_OK;
+}
+
+// SOLVE LAPLACE EQUATION WITH CSVW
+int cmd_Laplace_Csvw(char *cmd) {
+
+    // enter
+    debugprint(stddbg,"Entering cmd_Laplace_Csvw.\n");
+
+    if (CsvwSolution_ == NULL) {
+        WallPropSolution_ = new double [numNodes_];
+    }
+
+    int Laplacetype  = 3; // CSVW
+    calcWallPropDistribution(Laplacetype);
+
+    // cleanup
+    debugprint(stddbg,"Exiting cmd_Laplace_Csvw.\n");
+    return CV_OK;
+}
+
+// SOLVE LAPLACE EQUATION WITH P0VW
+int cmd_Laplace_P0vw(char *cmd) {
+
+    // enter
+    debugprint(stddbg,"Entering cmd_Laplace_P0vw.\n");
+
+    if (P0vwSolution_ == NULL) {
+        WallPropSolution_ = new double [numNodes_];
+    }
+
+    int Laplacetype  = 4; // P0VW
+    calcWallPropDistribution(Laplacetype);
+
+    // cleanup
+    debugprint(stddbg,"Exiting cmd_Laplace_P0vw.\n");
+    return CV_OK;
+}
+
 
 int cmd_set_Initial_Evw(char *cmd) {
 
@@ -1253,8 +1335,8 @@ int append_varwallprop_to_file(char *filename) {
   }
 
   if (wallpropsoln_ == NULL) {
-
-    nsd = 2;
+    
+    nsd = 5;                    // Thickness, Evw, Ksvw, Csvw, P0vw
     nshg = numNodes_;
     size = nsd*nshg;
 
@@ -1272,10 +1354,14 @@ int append_varwallprop_to_file(char *filename) {
     int nid = DisplacementNodeMap_[i];
   //  wallpropsoln_[numNodes_*0+nid-1] = WallpropSolution_[2*i+0];
   //  wallpropsoln_[numNodes_*1+nid-1] = WallpropSolution_[2*i+1];
-    //test! temporary
-//    wallpropsoln_[numNodes_*0+nid-1] = Displacement_thickness_ ;
+  // test! temporary
+  //    wallpropsoln_[numNodes_*0+nid-1] = Displacement_thickness_ ;
     wallpropsoln_[numNodes_*0+nid-1] = ThicknessSolution_[nid-1];
     wallpropsoln_[numNodes_*1+nid-1] = EvwSolution_[nid-1];
+
+    wallpropsoln_[numNodes_*2+nid-1] = KsvwSolution_[nid-1];
+    wallpropsoln_[numNodes_*3+nid-1] = CsvwSolution_[nid-1];
+    wallpropsoln_[numNodes_*4+nid-1] = P0vwSolution_[nid-1];
 
   }
 
@@ -1483,7 +1569,7 @@ int cmd_varwallprop_write_vtk(char *cmd) {
 
 
     if (ThicknessSolution_ != NULL) {
-     fprintf(fp,"SCALARS thickness double\n");
+     fprintf(fp,"SCALARS Thickness double\n");
      fprintf(fp,"LOOKUP_TABLE default\n");
     for (i = 0; i < numNodes_; i++) {
        scalarval=ThicknessSolution_[i];
@@ -1494,7 +1580,7 @@ int cmd_varwallprop_write_vtk(char *cmd) {
     }
 
    if (EvwSolution_ != NULL) {
-    fprintf(fp,"SCALARS Young_Mod double\n");
+    fprintf(fp,"SCALARS YoungsModulus double\n");
     fprintf(fp,"LOOKUP_TABLE default\n");
     for (i = 0; i < numNodes_; i++) {
 
@@ -1504,6 +1590,44 @@ int cmd_varwallprop_write_vtk(char *cmd) {
     }
 
     }
+
+    /* EXTERNAL TISSUE SUPPORT - ISL JULY 2019 */
+    if (KsvwSolution_ != NULL) {
+    fprintf(fp,"SCALARS SpringConstant double\n");
+    fprintf(fp,"LOOKUP_TABLE default\n");
+    for (i = 0; i < numNodes_; i++) {
+
+       scalarval=KsvwSolution_[i];
+      // printf("%lf\n",scalarval);
+        fprintf(fp,"%lf\n",scalarval);
+    }
+
+    }
+
+    if (CsvwSolution_ != NULL) {
+    fprintf(fp,"SCALARS DampingConstant double\n");
+    fprintf(fp,"LOOKUP_TABLE default\n");
+    for (i = 0; i < numNodes_; i++) {
+
+       scalarval=CsvwSolution_[i];
+      // printf("%lf\n",scalarval);
+        fprintf(fp,"%lf\n",scalarval);
+    }
+
+    }
+
+    if (P0vwSolution_ != NULL) {
+    fprintf(fp,"SCALARS ExternalPressure double\n");
+    fprintf(fp,"LOOKUP_TABLE default\n");
+    for (i = 0; i < numNodes_; i++) {
+
+       scalarval=P0vwSolution_[i];
+      // printf("%lf\n",scalarval);
+        fprintf(fp,"%lf\n",scalarval);
+    }
+
+    }
+
 
     fclose(fp);
 

--- a/Code/FlowSolvers/ThreeDSolver/svPre/supre.cxx
+++ b/Code/FlowSolvers/ThreeDSolver/svPre/supre.cxx
@@ -89,15 +89,18 @@ int*    DisplacementConn_[3];
 int     DisplacementNumNodes_    = 0;
 int*    DisplacementNodeMap_     = NULL;
 double* DisplacementSolution_    = NULL;
+
 #if(VER_VARWALL == 1)
-//variable wall thickness and Young Mod, deformable wall nodes, like DisplacementSolution_
+// variable wall properties
 double* WallPropSolution_    = NULL;  // hold any given var wall prop at a time
 double* ThicknessSolution_   = NULL;
 double* EvwSolution_         = NULL;
 double* KsvwSolution_        = NULL;
 double* CsvwSolution_        = NULL;
 double* P0vwSolution_        = NULL;
+int itissuesuppt             = 0;
 #endif
+
 double  Displacement_Evw_        = 0;
 double  Displacement_nuvw_       = 0;
 double  Displacement_thickness_  = 0;
@@ -177,5 +180,4 @@ int main(int argc, char *argv[]) {
   return 0;
 
 }
-
 

--- a/Code/FlowSolvers/ThreeDSolver/svPre/supre.cxx
+++ b/Code/FlowSolvers/ThreeDSolver/svPre/supre.cxx
@@ -75,7 +75,7 @@ double  init_v_[3];
 double* soln_ = NULL;
 double* dispsoln_ = NULL;
 #if(VER_VARWALL == 1)
-//variable wall thickness and Young Mod, all nodes
+//variable wall thickness, Young Mod, and 3 external tissue support constants for all nodes
 double* wallpropsoln_ = NULL;
 #endif
 double* acc_ = NULL;
@@ -91,8 +91,12 @@ int*    DisplacementNodeMap_     = NULL;
 double* DisplacementSolution_    = NULL;
 #if(VER_VARWALL == 1)
 //variable wall thickness and Young Mod, deformable wall nodes, like DisplacementSolution_
+double* WallPropSolution_    = NULL;  // hold any given var wall prop at a time
 double* ThicknessSolution_   = NULL;
-double* EvwSolution_   = NULL;
+double* EvwSolution_         = NULL;
+double* KsvwSolution_        = NULL;
+double* CsvwSolution_        = NULL;
+double* P0vwSolution_        = NULL;
 #endif
 double  Displacement_Evw_        = 0;
 double  Displacement_nuvw_       = 0;

--- a/Code/FlowSolvers/ThreeDSolver/svSolver/Input.h
+++ b/Code/FlowSolvers/ThreeDSolver/svSolver/Input.h
@@ -53,6 +53,8 @@
 
 using namespace std;
 
+// Function implementations in Cinput.cxx
+
 class Input {
 public:
 //  Input(const string &, const string &default_fname = "");

--- a/Code/FlowSolvers/ThreeDSolver/svSolver/addelmpvsqforsvls-closedloop-coronary.f
+++ b/Code/FlowSolvers/ThreeDSolver/svSolver/addelmpvsqforsvls-closedloop-coronary.f
@@ -83,7 +83,7 @@ c
 
 #include "cvFlowsolverOptions.h"
 
-!> Routine to add resistance of current step to faceRef array
+!> Routine to add resistance of current step to faceRes array
 
       SUBROUTINE AddElmpvsQForsvLS (faceRes, svLS_nFaces)     
 

--- a/Code/FlowSolvers/ThreeDSolver/svSolver/common_blocks/nomodule.h
+++ b/Code/FlowSolvers/ThreeDSolver/svSolver/common_blocks/nomodule.h
@@ -54,8 +54,9 @@ c      \\Common Block variables for "no module"
        INTEGER Lagrange, numLagrangeSrfs,nsrflistLagrange(0:MAXSURF),
      & iLagfile
        INTEGER MinNumIter,ideformwall, ivarwallprop
+       INTEGER itissuesuppt
        INTEGER applyWallDeformation
-       INTEGER iwallmassfactor,iwallstiffactor,
+       INTEGER iwallmassfactor, iwallstiffactor,
      & nProps
        INTEGER iGenInitialization,iGenFromFile
        INTEGER numNeumannSrfs,nsrflistNeumann(0:MAXSURF)
@@ -74,7 +75,7 @@ c                 ADDED FOR CONSISTENCY - CLOSED LOOP
      &            numNeumannSrfs,nsrflistNeumann,
      &            iGenInitialization,iGenFromFile,
      &            numDirichletSrfs,nsrflistDirichlet,
-c                 ===================================
+c                 ==============================================
      &            numImpSrfs, nsrflistImp,impfile,
      &            numRCRSrfs, nsrflistRCR,ircrfile,
      &            numCORSrfs,nsrflistCOR,icorfile,
@@ -82,13 +83,12 @@ c                 ===================================
      &            numCalcSrfs, nsrflistCalc,
 c                 ADDED FOR CONSISTENCY - CLOSED LOOP
      &            numNormalSrfs,nsrflistNormal,
-c                 ===================================
+c                 ==============================================
      &            Lagrange, numLagrangeSrfs,
      &            nsrflistLagrange,iLagfile,
      &            MinNumIter,
      &            ideformwall, applyWallDeformation,
-c                 ADDED FOR CONSISTENCY - VARWALL
-     &            ivarwallprop, 
-c                 ===============================
+     &            ivarwallprop, itissuesuppt,
+c                 ==============================================
      &            iwallmassfactor,
      &            iwallstiffactor, nProps

--- a/Code/FlowSolvers/ThreeDSolver/svSolver/common_blocks/nomodule.h
+++ b/Code/FlowSolvers/ThreeDSolver/svSolver/common_blocks/nomodule.h
@@ -40,9 +40,9 @@ c  DAMAGE.
 
 c      \\Common Block variables for "no module"
 
-       REAL*8 bcttimescale,ValueListResist(0:MAXSURF),rhovw,thicknessvw,
-     & evw,rnuvw
-       REAL*8 rshearconstantvw, betai,rescontrol,ResCriteria,
+       REAL*8 bcttimescale,ValueListResist(0:MAXSURF),rhovw,rnuvw, 
+     & rshearconstantvw, thicknessvw, evw, ksvw, csvw, p0vw
+       REAL*8 betai,rescontrol,ResCriteria,
      & backflowstabcoef
        INTEGER icardio, itvn, ipvsq, numResistSrfs,
      & nsrflistResist(0:MAXSURF)
@@ -63,8 +63,11 @@ c      \\Common Block variables for "no module"
        INTEGER numNormalSrfs,nsrflistNormal(0:MAXSURF)
 
         common /nomodule/ bcttimescale,ValueListResist,
-     &            rhovw, thicknessvw, evw, rnuvw,
-     &            rshearconstantvw, betai,rescontrol,ResCriteria,
+     &            rhovw, rnuvw, rshearconstantvw, thicknessvw, evw,
+c         ======= External Tissue Support / ISL July 2019 ======
+     &            ksvw, csvw, p0vw,
+c         ======================================================
+     &            betai, rescontrol,ResCriteria,
      &            backFlowStabCoef, icardio, itvn, ipvsq,
      &            numResistSrfs, nsrflistResist,
 c                 ADDED FOR CONSISTENCY - CLOSED LOOP

--- a/Code/FlowSolvers/ThreeDSolver/svSolver/common_c.h
+++ b/Code/FlowSolvers/ThreeDSolver/svSolver/common_c.h
@@ -519,7 +519,7 @@ extern "C" {
     // CLOSED LOOP
     int numNormalSrfs;
     int nsrflistNormal[MAXSURF+1];
-    //============================
+    // ============================
     int Lagrange;
     int numLagrangeSrfs;
     int nsrflistLagrange[MAXSURF+1];
@@ -529,7 +529,9 @@ extern "C" {
     int applyWallDeformation;
     // VARWALL
     int ivarwallprop;
-    // =======
+    // EXTERNAL TISSUE SUPPORT
+    int itissuesuppt;
+    // ========================
     int iwallmassfactor;
     int iwallstiffactor;
     int nProps;

--- a/Code/FlowSolvers/ThreeDSolver/svSolver/common_c.h
+++ b/Code/FlowSolvers/ThreeDSolver/svSolver/common_c.h
@@ -477,10 +477,13 @@ extern "C" {
     double bcttimescale;
     double ValueListResist[MAXSURF+1];
     double rhovw;
-    double thicknessvw;
-    double evw;
     double rnuvw;
     double rshearconstantvw;
+    double thicknessvw;
+    double evw;
+    double ksvw;
+    double csvw;
+    double p0vw;
     double betai;
     double rescontrol;
     double ResCriteria;

--- a/Code/FlowSolvers/ThreeDSolver/svSolver/elmgmr-closedloop-varwall.f
+++ b/Code/FlowSolvers/ThreeDSolver/svSolver/elmgmr-closedloop-varwall.f
@@ -386,7 +386,7 @@ c
 #if (VER_VARWALL == 1)
           if (ivarwallprop .eq. 1) then
 
-            call AsBMFG2 (u,                       y,
+            call AsBMFG2 (u,                      y,
      &                   ac,                      x,
      &                   tmpshpb,               tmpshglb,
      &                   mienb(iblk)%p,           mmatb(iblk)%p,

--- a/Code/FlowSolvers/ThreeDSolver/svSolver/genbkb-varwall.f
+++ b/Code/FlowSolvers/ThreeDSolver/svSolver/genbkb-varwall.f
@@ -72,6 +72,8 @@ C
       INTEGER             itpblk     
       INTEGER             n,           n1,          n2
       INTEGER             neltp,       numnbc
+      INTEGER             nwallprop
+
 C
         integer, allocatable :: ientp(:,:),iBCBtp(:,:)
         real*8, allocatable :: BCBtp(:,:)
@@ -177,7 +179,11 @@ c
 
 #if(VER_VARWALL == 1)
               IF (ivarwallprop .eq. 1) THEN
-                allocate (wallpropelem(nelblb)%p(npro,2))
+
+c....           EXTERNAL TISSUE SUPPORT - ISL JULY 2019
+c,,,,           var thicknessvw, evw, ksvw, csvw, p0vw
+                nwallprop = 5
+                allocate (wallpropelem(nelblb)%p(npro,nwallprop))
               ENDIF
 #endif
 c

--- a/Code/FlowSolvers/ThreeDSolver/svSolver/genbkb-varwall.f
+++ b/Code/FlowSolvers/ThreeDSolver/svSolver/genbkb-varwall.f
@@ -178,12 +178,19 @@ c
               allocate (mmatb(nelblb)%p(npro))
 
 #if(VER_VARWALL == 1)
+
               IF (ivarwallprop .eq. 1) THEN
 
 c....           EXTERNAL TISSUE SUPPORT - ISL JULY 2019
 c,,,,           var thicknessvw, evw, ksvw, csvw, p0vw
-                nwallprop = 5
+                IF (itissuesuppt .eq. 1) THEN
+                  nwallprop = 5
+                ELSE 
+                  nwallprop = 2
+                ENDIF
+
                 allocate (wallpropelem(nelblb)%p(npro,nwallprop))
+
               ENDIF
 #endif
 c

--- a/Code/FlowSolvers/ThreeDSolver/svSolver/global.h
+++ b/Code/FlowSolvers/ThreeDSolver/svSolver/global.h
@@ -58,7 +58,7 @@ c                  common_c.h ALSO
 c
         parameter     ( MAXBLK = 5000, MAXTS = 100)
         parameter     ( MAXSH = 32, NSD = 3 )
-        parameter (MAXQPT = 125)
+        parameter     ( MAXQPT = 125 )
         parameter     ( MAXTOP = 6, MAXSURF=199 )
 c
 c----------------------------------------------------------------------

--- a/Code/FlowSolvers/ThreeDSolver/svSolver/input.config
+++ b/Code/FlowSolvers/ThreeDSolver/svSolver/input.config
@@ -286,11 +286,12 @@
 
 # Deformable Wall Settings
 # ======================== 
-  Deformable Wall: False #False ideformwall=0, True ideformwall=1
-  Variable Wall Properties: False # False ivarwallprop=0, True ivarwallprop=1 
-  Number of Wall Properties per Node: 10 # nProps
-                                         # nProps=10: Isotropic
-                                         # nProps=21: Orthotropic
+  Deformable Wall: False                                  # False ideformwall=0,     True ideformwall=1
+  Variable Wall Thickness and Young Mod: False            # False ivarwallprop=0,    True ivarwallprop=1
+  External Tissue Support: False                          # False itissuesuppt=0,    True itissuesuppt=1
+  Number of Wall Properties per Node: 10                  # nProps
+                                                          # nProps=10: Isotropic
+                                                          # nProps=21: Orthotropic
   Density of Vessel Wall: NODEFAULT                       # rhovw
   Poisson Ratio of Vessel Wall: 0.5                       # rnuvw
   Shear Constant of Vessel Wall: NODEFAULT                # rshearconstantvw

--- a/Code/FlowSolvers/ThreeDSolver/svSolver/input.config
+++ b/Code/FlowSolvers/ThreeDSolver/svSolver/input.config
@@ -287,15 +287,18 @@
 # Deformable Wall Settings
 # ======================== 
   Deformable Wall: False #False ideformwall=0, True ideformwall=1
-  Variable Wall Thickness and Young Mod: False # False ivarwallprop=0, True ivarwallprop=1 
+  Variable Wall Properties: False # False ivarwallprop=0, True ivarwallprop=1 
   Number of Wall Properties per Node: 10 # nProps
                                          # nProps=10: Isotropic
                                          # nProps=21: Orthotropic
-  Density of Vessel Wall: NODEFAULT # rhovw
-  Thickness of Vessel Wall: NODEFAULT # thicknessvw
-  Young Mod of Vessel Wall: NODEFAULT # evw
-  Poisson Ratio of Vessel Wall: 0.5 # rnuvw
-  Shear Constant of Vessel Wall: NODEFAULT # rshearconstantvw
+  Density of Vessel Wall: NODEFAULT                       # rhovw
+  Poisson Ratio of Vessel Wall: 0.5                       # rnuvw
+  Shear Constant of Vessel Wall: NODEFAULT                # rshearconstantvw
+  Thickness of Vessel Wall: NODEFAULT                     # thicknessvw
+  Young Mod of Vessel Wall: NODEFAULT                     # evw
+  Spring Constant of External Support: NODEFAULT          # ksvw
+  Damping Constant of External Support: NODEFAULT         # csvw
+  External Pressure: NODEFAULT                            # p0vw
   Wall Mass Matrix for LHS: True   # iwallmassfactor=1
 # Wall Mass Matrix for LHS: False  # iwallmassfactor=0
   Wall Stiffness Matrix for LHS: True   # iwallstiffactor=1

--- a/Code/FlowSolvers/ThreeDSolver/svSolver/input_fform.cxx
+++ b/Code/FlowSolvers/ThreeDSolver/svSolver/input_fform.cxx
@@ -86,10 +86,10 @@ int input_fform(char inpfname[])
 //    else strcpy(complete_filename,".");
 //    strcat(complete_filename, "/input.config");
 //    printf("\n Complete Filename: %s \n", complete_filename);
-	if(myrank==0){
-		printf("Solver Input Files listed as below:\n------------------------------------\n");
-		printf(" Local Config: %s \n", inpfname);
-	}
+  if(myrank==0){
+    printf("Solver Input Files listed as below:\n------------------------------------\n");
+    printf(" Local Config: %s \n", inpfname);
+  }
 //    string def(complete_filename);
 //    Input inp(inpfname,def);
     string inpfile(inpfname);
@@ -99,35 +99,35 @@ int input_fform(char inpfname[])
     printf("Parameter Values setup as below:\n----------------------------------------------\n");
     }
     // ========================
-	// BCT CONTROL KEY WORDS
+  // BCT CONTROL KEY WORDS
     // ========================
     strvalue=(string)inp.GetValue("Time Varying Boundary Conditions From File","True",false,true);
     (strvalue=="True")? nomodule.itvn = 1: nomodule.itvn = 0;
     if ( nomodule.itvn ==1){
         strvalue=(string)inp.GetValue("BCT File Type","DAT",false,true);
         if(strvalue=="DAT"){
-        	inpdat.BCTFlag=0;
+          inpdat.BCTFlag=0;
         }else if(strvalue=="VTP"){
-        	inpdat.BCTFlag=1;
+          inpdat.BCTFlag=1;
         }else{
-        	if(myrank==0){
-        	cerr << " ERROR: Invalid BCT File Type." << endl;
-        	}
-        	return 001;
+          if(myrank==0){
+          cerr << " ERROR: Invalid BCT File Type." << endl;
+          }
+          return 001;
         }
 
         inpdat.BCTFileNumber = inp.GetValue("Number of BCT Files","1",false,true);
 
         strvalue=(string)inp.GetValue("BCT Matching Type","Global Node ID",false,true);
         if(strvalue=="Coordinates"){
-        	inpdat.BCTMatchingFlag=0;
+          inpdat.BCTMatchingFlag=0;
         }else if(strvalue=="Global Node ID"){
-        	inpdat.BCTMatchingFlag=1;
+          inpdat.BCTMatchingFlag=1;
         }else{
-        	if(myrank==0){
-        	cerr << " ERROR: Invalid BCT Matching Type." << endl;
-        	}
-        	return 001;
+          if(myrank==0){
+          cerr << " ERROR: Invalid BCT Matching Type." << endl;
+          }
+          return 001;
         }
 
         nomodule.bcttimescale = inp.GetValue("BCT Time Scale Factor","1.0",false,true);
@@ -160,10 +160,10 @@ int input_fform(char inpfname[])
     // Solve Scalars
     solscalr = inp.GetValue("Solve Scalars","0",false,false);
     if ( solscalr > 4 ) {
-    	if(myrank==0){
-    	 cout << " Only Four Scalars are supported \n";
+      if(myrank==0){
+       cout << " Only Four Scalars are supported \n";
          cout <<" Please reduce number of scalars \n";
-    	}
+      }
       exit(1);
     }
     inpdat.impl[0] = 10*solflow+solscalr*100+solheat;
@@ -234,10 +234,10 @@ int input_fform(char inpfname[])
     }
 
     if(nomodule.numCalcSrfs=inp.GetValue("Number of Surfaces which Output Pressure and Flow","0",false,true)){
-	    ivec = inp.GetValue("List of Output Surfaces","",true,true);
-	    for(i=0; i<MAXSURF+1; i++) nomodule.nsrflistCalc[i] = 0;
+      ivec = inp.GetValue("List of Output Surfaces","",true,true);
+      for(i=0; i<MAXSURF+1; i++) nomodule.nsrflistCalc[i] = 0;
         for(i=0; i<nomodule.numCalcSrfs; i++){
-	        nomodule.nsrflistCalc[i+1]=ivec[i];
+          nomodule.nsrflistCalc[i+1]=ivec[i];
         }
     }
     ivec.erase(ivec.begin(),ivec.end());
@@ -402,7 +402,7 @@ int input_fform(char inpfname[])
     if( strvalue =="CG" ){
       inpdat.svLSType=1;
     }else if ( strvalue =="GMRES" ){
-    	inpdat.svLSType=2;
+      inpdat.svLSType=2;
     }else if( strvalue =="NS"){
       inpdat.svLSType=3;
     }else{
@@ -476,7 +476,7 @@ int input_fform(char inpfname[])
       inpdat.rhoinf[0] = -1 ;
     }
     else {
-    	inpdat.rhoinf[0] = (double)inp.GetValue("Time Integration Rho Infinity","0.5",false,true);
+      inpdat.rhoinf[0] = (double)inp.GetValue("Time Integration Rho Infinity","0.5",false,true);
     }
     
     strvalue=(string)inp.GetValue("Predictor at Start of Step","Same Velocity",false,false);
@@ -537,7 +537,7 @@ int input_fform(char inpfname[])
     else if(strvalue == "DC-minimum") solpar.iDC = 3;
     else {
       if(myrank==0){
-    	cout<< "Condition not defined for Discontinuity Capturing \n ";
+      cout<< "Condition not defined for Discontinuity Capturing \n ";
       }
       exit(1);
     }
@@ -554,7 +554,7 @@ int input_fform(char inpfname[])
         if(genpar.ipord == 1 ) genpar.idiff = 1;
         else genpar.idiff = 2;
     }else{
-    	genpar.idiff = 0;
+      genpar.idiff = 0;
     }
 
     timdat.flmpl = inp.GetValue("Lumped Mass Fraction on Left-hand-side","0",false,false);
@@ -575,9 +575,9 @@ int input_fform(char inpfname[])
     nomodule.ipvsq=0;
     if(nomodule.icardio = inp.GetValue("Number of Coupled Surfaces","0",false,true)){
       if ( nomodule.icardio > MAXSURF ) {
-    	 if(myrank==0){
-    	  cout << "Number of Coupled Surfaces > MAXSURF \n";
-    	 }
+       if(myrank==0){
+        cout << "Number of Coupled Surfaces > MAXSURF \n";
+       }
         exit(1);
       } 
       strvalue=(string)inp.GetValue("Pressure Coupling","Implicit",false,true);
@@ -610,7 +610,7 @@ int input_fform(char inpfname[])
       if ( strvalue == "True")
          nomodule.iGenFromFile = 1;
       else
-    	 nomodule.iGenFromFile = 0;
+       nomodule.iGenFromFile = 0;
 
       if(nomodule.numDirichletSrfs=inp.GetValue("Number of Dirichlet Surfaces","0",false,false)){
           ivec = inp.GetValue("List of Dirichlet Surfaces","",true,true);
@@ -629,10 +629,10 @@ int input_fform(char inpfname[])
       }
 
       if(nomodule.numNormalSrfs=inp.GetValue("Number of Normal Constrained Surfaces","0",false,false)){
-	     ivec = inp.GetValue("List of Normal Constrained Surfaces","",true,true);
+       ivec = inp.GetValue("List of Normal Constrained Surfaces","",true,true);
          for(i=0; i<MAXSURF+1; i++) nomodule.nsrflistNormal[i] = 0;
          for(i=0; i<nomodule.numNormalSrfs; i++){
-	        nomodule.nsrflistNormal[i+1]=ivec[i];
+          nomodule.nsrflistNormal[i+1]=ivec[i];
          }
      }
 //    =============================================
@@ -664,7 +664,7 @@ int input_fform(char inpfname[])
 
 #if(VER_CORONARY == 1)
       //CORONARY
-	  if(nomodule.numCORSrfs=inp.GetValue("Number of COR Surfaces","0",false,false)){
+    if(nomodule.numCORSrfs=inp.GetValue("Number of COR Surfaces","0",false,false)){
           ivec = inp.GetValue("List of COR Surfaces","",true,true);
           for(i=0;i<MAXSURF+1; i++) nomodule.nsrflistCOR[i] = 0;
           for(i=0; i< nomodule.numCORSrfs; i++){
@@ -676,77 +676,88 @@ int input_fform(char inpfname[])
       }      
 #endif
 //      if(nomodule.numCalcSrfs=inp.GetValue("Number of Surfaces which Output Pressure and Flow","0",false)){
-//	     ivec = inp.GetValue("List of Output Surfaces","",true);
+//       ivec = inp.GetValue("List of Output Surfaces","",true);
 //         for(i=0; i<MAXSURF+1; i++) nomodule.nsrflistCalc[i] = 0;
 //          for(i=0; i<nomodule.numCalcSrfs; i++){
-//	        nomodule.nsrflistCalc[i+1]=ivec[i];
+//          nomodule.nsrflistCalc[i+1]=ivec[i];
 //          }
 //         }
 
-	  //Backflow control
-	  nomodule.backFlowStabCoef = (double)inp.GetValue("Backflow Stabilization Coefficient","0.2",false,true);
+    //Backflow control
+    nomodule.backFlowStabCoef = (double)inp.GetValue("Backflow Stabilization Coefficient","0.2",false,true);
 
-	  if(nomodule.numVisFluxSrfs=inp.GetValue("Number of Surfaces which zero out in-plane tractions","0",false,false)){
-		 ivec = inp.GetValue("List of Surfaces which zero out in-plane tractions","",true,true);
-		 for(i=0; i<MAXSURF+1; i++) nomodule.nsrflistVisFlux[i] = 0;
-		 for(i=0; i<nomodule.numVisFluxSrfs; i++){
-			nomodule.nsrflistVisFlux[i+1]=ivec[i];
-		 }
-	  }
+    if(nomodule.numVisFluxSrfs=inp.GetValue("Number of Surfaces which zero out in-plane tractions","0",false,false)){
+     ivec = inp.GetValue("List of Surfaces which zero out in-plane tractions","",true,true);
+     for(i=0; i<MAXSURF+1; i++) nomodule.nsrflistVisFlux[i] = 0;
+     for(i=0; i<nomodule.numVisFluxSrfs; i++){
+      nomodule.nsrflistVisFlux[i+1]=ivec[i];
+     }
+    }
       strvalue=(string)inp.GetValue("Lagrange Multipliers","False",false,false);
-	  if ( strvalue == "True")
+    if ( strvalue == "True")
          nomodule.Lagrange = 1; else nomodule.Lagrange = 0;
-	  if ( nomodule.Lagrange ==1) {
+    if ( nomodule.Lagrange ==1) {
          nomodule.numLagrangeSrfs = inp.GetValue("Number of Constrained Surfaces","",true,true);
-	     ivec = inp.GetValue("List of Constrained Surfaces","",true,true);
+       ivec = inp.GetValue("List of Constrained Surfaces","",true,true);
          for(i=0;i<MAXSURF+1; i++) nomodule.nsrflistLagrange[i] = 0;
-		 for(i=0; i< nomodule.numLagrangeSrfs; i++) {
+     for(i=0; i< nomodule.numLagrangeSrfs; i++) {
                     nomodule.nsrflistLagrange[i+1] = ivec[i];
-		 }
-		 strvalue=(string)inp.GetValue("Constrained Surface Information From File","False",false,true);
+     }
+     strvalue=(string)inp.GetValue("Constrained Surface Information From File","False",false,true);
          if ( strvalue == "True")
             nomodule.iLagfile = 1; else nomodule.iLagfile = 0;
-	  }
+    }
 
-	}
+  }
 
    // =========================
    // DEEFORMABLE WALL SETTINGS
    // =========================
-   nomodule.ideformwall = 0;
-   nomodule.ivarwallprop = 0;
+   nomodule.ideformwall   = 0;
+   nomodule.ivarwallprop  = 0;
+   nomodule.itissuesuppt  = 0;
+
+   // Set Deformable Wall Flag
    strvalue=(string)inp.GetValue("Deformable Wall","False",false,true);
-   if(strvalue=="True"){
-     // Set Deformable Wall Flag
+   if (strvalue=="True") {
      nomodule.ideformwall = 1;
 
-#if(VER_VARWALL == 1)
-     // Check Variable wall properties
-     strvalue=(string)inp.GetValue("Variable Wall Properties","False",false,true);
+#if (VER_VARWALL == 1)
+     // Check variable wall thickness and young's modulus
+     strvalue=(string)inp.GetValue("Variable Wall Thickness and Young Mod","False",false,true);
      if (strvalue == "True") {
        nomodule.ivarwallprop = 1;
-     } else {
-       nomodule.ivarwallprop = 0;
-     } 
+     }
 #endif
+     // Check External Tissue Support
+     strvalue=(string)inp.GetValue("External Tissue Support","False",false,true);
+     if (strvalue=="True") {
+       nomodule.itissuesuppt = 1;
+     }
 
-     // Read isotropic material properties
+     // 4 cases. Read isotropic material properties. 
      if (nomodule.ivarwallprop == 0) {
-
        nomodule.thicknessvw = inp.GetValue("Thickness of Vessel Wall","",true,true);
        nomodule.evw = inp.GetValue("Young Mod of Vessel Wall","",true,true);
-       nomodule.ksvw = inp.GetValue("Spring Constant of External Support", "", true, true);
-       nomodule.csvw = inp.GetValue("Damping Constant of External Support", "", true, true);
-       nomodule.p0vw = inp.GetValue("External Pressure", "", true, true);
 
+       if (nomodule.itissuesuppt == 1) {
+         nomodule.ksvw = inp.GetValue("Spring Constant of External Support", "", true, true);
+         nomodule.csvw = inp.GetValue("Damping Constant of External Support", "", true, true);
+         nomodule.p0vw = inp.GetValue("External Pressure", "", true, true);
+       }
+     
+     // For variable wall properties, read isotropic values from File
      } else {
-       // Read Isotropic values from File
        nomodule.thicknessvw = 0.0;
        nomodule.evw = 0.0;
-       nomodule.ksvw = 0.0;
-       nomodule.csvw = 0.0;
-       nomodule.p0vw = 0.0;
+
+       if (nomodule.itissuesuppt == 1) {
+         nomodule.ksvw = 0.0;
+         nomodule.csvw = 0.0;
+         nomodule.p0vw = 0.0;
+       }
      }
+
      // Density and shear constant of the walls need to be defined
      nomodule.rhovw = inp.GetValue("Density of Vessel Wall","",true,true);
      nomodule.rshearconstantvw = inp.GetValue("Shear Constant of Vessel Wall","",true,true);
@@ -755,79 +766,79 @@ int input_fform(char inpfname[])
      nomodule.nProps = inp.GetValue("Number of Wall Properties per Node","10",false,true);
 
      strvalue=(string)inp.GetValue("Wall Mass Matrix for LHS","True",false,true);
-     if(strvalue == "True"){
+     if (strvalue == "True") {
        nomodule.iwallmassfactor = 1;
-     }else{
+     } else {
        nomodule.iwallmassfactor = 0;
      }
      strvalue=(string)inp.GetValue("Wall Stiffness Matrix for LHS","True",false,true);
-     if(strvalue == "True"){
+     if (strvalue == "True") {
        nomodule.iwallstiffactor = 1;
-     }else{
+     } else {
        nomodule.iwallstiffactor = 0;
      }
-    }
+   }  
 
-    // ============================
-    // Non-linear Iteration Control
-    // ============================
-    strvalue=(string)inp.GetValue("Residual Control","True",false,true);
-    if (strvalue == "True") nomodule.rescontrol = 1;
-    else nomodule.rescontrol = 0;
-    if ( nomodule.rescontrol ==1) {
+   // ============================
+   // Non-linear Iteration Control
+   // ============================
+   strvalue=(string)inp.GetValue("Residual Control","True",false,true);
+   if (strvalue == "True") nomodule.rescontrol = 1;
+   else nomodule.rescontrol = 0;
+   if (nomodule.rescontrol == 1) {
        nomodule.ResCriteria = inp.GetValue("Residual Criteria","0.01",false,true);
        nomodule.MinNumIter = inp.GetValue("Minimum Required Iterations","3",false,true);
-    }
-    // Step Sequencing
-    ivec = inp.GetValue("Step Construction","0 1 0 1 0 1 0 1 0 1 0 1 0 1 0 1 0 1 0 1",false,true);
-    sequence.seqsize = ivec.size();
-    if( sequence.seqsize > 100 || sequence.seqsize < 2 ){
-      if(myrank==0){
-    	cerr<<"Sequence size must be between 2 and 100 "<<endl;
-      }
-    }
-    for(i=0; i< sequence.seqsize; i++){
-      sequence.stepseq[i] = ivec[i];
-    }
+   }
+   // Step Sequencing
+   ivec = inp.GetValue("Step Construction","0 1 0 1 0 1 0 1 0 1 0 1 0 1 0 1 0 1 0 1",false,true);
+   sequence.seqsize = ivec.size();
+   if (sequence.seqsize > 100 || sequence.seqsize < 2) {
+       if (myrank==0) {
+       cerr << "Sequence size must be between 2 and 100 " << endl;
+       }
+   }
+   for (i=0; i< sequence.seqsize; i++) {
+       sequence.stepseq[i] = ivec[i];
+   }
 
-    // ============================
-    // Task Control
-    // ============================
-    strvalue=(string)inp.GetValue("Solver Task","Full Simulation",false,true);
-    if( strvalue =="Full Simulation" ){
-        inpdat.solverTask=0;
-    }else if ( strvalue =="Only Partition" ){
-        inpdat.solverTask=1;
-    }else{
-        if(myrank==0){
-            cerr << " ERROR: Invalid Solver Task." << endl;
-        }
-        return 001;
-    }
+   // ============================
+   // Task Control
+   // ============================
+   strvalue=(string)inp.GetValue("Solver Task","Full Simulation",false,true);
+   if ( strvalue =="Full Simulation" ) {
+       inpdat.solverTask=0;
+   } else if ( strvalue =="Only Partition" ) {
+       inpdat.solverTask=1;
+   } else {
+       if(myrank==0){
+           cerr << " ERROR: Invalid Solver Task." << endl;
+       }
+       return 001;
+   }
 
-    // ==================
-    // SCALING PARAMETERS
-    // ==================
-    outpar.ro = inp.GetValue("Density Scaling","1.0",false,false);
-    outpar.vel = inp.GetValue("Velocity Scaling","1.0",false,false);
-    outpar.press = inp.GetValue("Pressure Scaling","1.0",false,false);
-    outpar.temper = inp.GetValue("Temperature Scaling","1.0",false,false);
-    outpar.entrop = inp.GetValue("Entropy Scaling","1.0",false,false);
+   // ==================
+   // SCALING PARAMETERS
+   // ==================
+   outpar.ro = inp.GetValue("Density Scaling","1.0",false,false);
+   outpar.vel = inp.GetValue("Velocity Scaling","1.0",false,false);
+   outpar.press = inp.GetValue("Pressure Scaling","1.0",false,false);
+   outpar.temper = inp.GetValue("Temperature Scaling","1.0",false,false);
+   outpar.entrop = inp.GetValue("Entropy Scaling","1.0",false,false);
 
-    cout << endl ;
+   cout << endl;
   }
-  catch ( exception &e ) {
-	ierr = 001;
-	if(myrank==0){
-	 cout << endl << "Input exception: " << e.what() << endl << endl;
-     print_error_code(ierr);
-	}
-    return ierr;
-  }
-
-  return ierr;
   
+  catch ( exception &e ) {
+   ierr = 001;
+   if (myrank==0) {
+       cout << endl << "Input exception: " << e.what() << endl << endl;
+       print_error_code(ierr);
+   }
+   return ierr;
+  }
+  return ierr;
 }
+
 
 void print_error_code(int ierr) {
   /*

--- a/Code/FlowSolvers/ThreeDSolver/svSolver/input_fform.cxx
+++ b/Code/FlowSolvers/ThreeDSolver/svSolver/input_fform.cxx
@@ -722,22 +722,30 @@ int input_fform(char inpfname[])
 
 #if(VER_VARWALL == 1)
      // Check Variable wall properties
-     strvalue=(string)inp.GetValue("Variable Wall Thickness and Young Mod","False",false,true);
-     if(strvalue == "True"){
+     strvalue=(string)inp.GetValue("Variable Wall Properties","False",false,true);
+     if (strvalue == "True") {
        nomodule.ivarwallprop = 1;
-     }else{
+     } else {
        nomodule.ivarwallprop = 0;
      } 
 #endif
 
-     // Read isotropic material properties only if the thi
-     if(nomodule.ivarwallprop == 0){
+     // Read isotropic material properties
+     if (nomodule.ivarwallprop == 0) {
+
        nomodule.thicknessvw = inp.GetValue("Thickness of Vessel Wall","",true,true);
        nomodule.evw = inp.GetValue("Young Mod of Vessel Wall","",true,true);
-     }else{
+       nomodule.ksvw = inp.GetValue("Spring Constant of External Support", "", true, true);
+       nomodule.csvw = inp.GetValue("Damping Constant of External Support", "", true, true);
+       nomodule.p0vw = inp.GetValue("External Pressure", "", true, true);
+
+     } else {
        // Read Isotropic values from File
        nomodule.thicknessvw = 0.0;
        nomodule.evw = 0.0;
+       nomodule.ksvw = 0.0;
+       nomodule.csvw = 0.0;
+       nomodule.p0vw = 0.0;
      }
      // Density and shear constant of the walls need to be defined
      nomodule.rhovw = inp.GetValue("Density of Vessel Wall","",true,true);

--- a/Code/FlowSolvers/ThreeDSolver/svSolver/main.cxx
+++ b/Code/FlowSolvers/ThreeDSolver/svSolver/main.cxx
@@ -304,12 +304,13 @@ int main( int argc, char *argv[] ) {
         }
 
         if(inpdat.solverTask==0){
+
             input(&size,&myrank);
+            
             /* now we can start the solver */
             proces();
         }
-    }
-    else{
+    } else{
         printf("error during reading ascii input \n");
     }
 

--- a/Code/FlowSolvers/ThreeDSolver/svSolver/partition.cxx
+++ b/Code/FlowSolvers/ThreeDSolver/svSolver/partition.cxx
@@ -349,7 +349,7 @@ Partition_Problem( int  numProcs,
     readheader_( &igeombc, "number of variables", (void*)iarray, 
                  &ione, "integer", iformat );
 
-    ndof = iarray[0] ;
+    ndof = iarray[0];
 
     readheader_( &igeombc, "maximum number of element nodes", (void*)iarray, 
                  &ione, "integer", iformat );
@@ -695,6 +695,7 @@ Partition_Problem( int  numProcs,
 
     /* varwallprop */
 #if(VER_VARWALL == 1)
+
   if (nomodule.ivarwallprop != 0) {
     iarray[0]=0;
     readheader_( &igeombc, "varwallprop", (void*)iarray, &itwo, "double",
@@ -753,7 +754,7 @@ Partition_Problem( int  numProcs,
     }
   }
 #endif
-   
+
     /* let us take care of Essential BCs.*/
     // BCs are in the indirect numbering of nBC so only nBC needs to be sorted 
     // according to nshg
@@ -938,7 +939,6 @@ Partition_Problem( int  numProcs,
     iBCpart.clear();
     BCpart.clear();
         
-
     /* done writing ebcs */
 
     /* ienb and BCB and iBCB */
@@ -1298,8 +1298,8 @@ Partition_Problem( int  numProcs,
 
     delete [] periodic;
 
-    // now to generate ILwork and Periodicity
 
+    // now to generate ILwork and Periodicity
     vector<int>  ilwork;
 
 #if defined ( DEBUG)
@@ -1474,6 +1474,7 @@ Partition_Problem( int  numProcs,
     delete [] rtask;
     delete [] stask;
 
+
     // write ncorp
     // generating ncorp 
     // ncorp is our map between the "partition local" and the global (sms) 
@@ -1576,7 +1577,6 @@ Partition_Problem( int  numProcs,
     }
 
 
-
 //       The end of writing data
 
     //write restart
@@ -1588,7 +1588,7 @@ Partition_Problem( int  numProcs,
 
     nshg  = iarray[0];
     ndof  = iarray[1];
-    isize = nshg * ndof ;
+    isize = nshg * ndof;
 
     double* solution = new double [ isize ];
 
@@ -1612,7 +1612,8 @@ Partition_Problem( int  numProcs,
         }
     }
       
-    delete [] solution;   
+    delete [] solution; 
+
 
     int nsd = 3;
     double* displacement;
@@ -1688,7 +1689,14 @@ Partition_Problem( int  numProcs,
 	  }
 
 #if(VER_VARWALL == 1)
-    int nsdwp = 5;  // variable thicknessvw, evw, ksvw, csvw, p0vw
+
+    int nsdwp;
+    if (nomodule.itissuesuppt == 1) {
+        nsdwp = 5;               // variable thicknessvw, evw, ksvw, csvw, p0vw
+    } else {
+        nsdwp = 2;               // variable thicknessvw, evw
+    }
+
     double* wallprop;
     double* fWallprop;
     int nshgLocalWallprop;
@@ -1716,18 +1724,18 @@ Partition_Problem( int  numProcs,
 		  readdatablock_( &irestart,"varwallprop?", (void*)wallprop, &isize,
 						"double", iformat  );
 
-		  for( int x = 1; x < nshg+1; x++ ){
-			for( map<int,int>::iterator pIter = ParallelData[x].begin();
+		  for (int x = 1; x < nshg+1; x++) {
+			for (map<int,int>::iterator pIter = ParallelData[x].begin();
 				 pIter != ParallelData[x].end();
-				 pIter++ ) {
-				for( int v=0; v< nsdwp ; v++ )
+				 pIter++) {
+				for (int v = 0; v < nsdwp ; v++)
 					wallpropPart[ (*pIter).first ][ (*pIter).second ].push_back(
 													   wallprop[ v*nshg + x -1 ] );
 			}
 		  }
 
 		  delete [] wallprop;
-      }else{
+      } else {
           use_restart=0;
       }
     }

--- a/Code/FlowSolvers/ThreeDSolver/svSolver/partition.cxx
+++ b/Code/FlowSolvers/ThreeDSolver/svSolver/partition.cxx
@@ -1688,7 +1688,7 @@ Partition_Problem( int  numProcs,
 	  }
 
 #if(VER_VARWALL == 1)
-    int nsdwp = 2;
+    int nsdwp = 5;  // variable thicknessvw, evw, ksvw, csvw, p0vw
     double* wallprop;
     double* fWallprop;
     int nshgLocalWallprop;
@@ -1707,7 +1707,8 @@ Partition_Problem( int  numProcs,
       	  use_restart=1;
 
 		  nshg  = iarray[0];
-		  nsdwp  = iarray[1];
+		  nsdwp = iarray[1];
+
 		  isize = nshg * nsdwp ;
 
 		  wallprop = new double [ isize ];
@@ -1750,7 +1751,7 @@ Partition_Problem( int  numProcs,
         }
 
 #if(VER_VARWALL == 1)
-        if (nomodule.ivarwallprop != 0 && use_restart==1) {
+        if (nomodule.ivarwallprop != 0 && use_restart==1) {         
           nshgLocalWallprop = wallpropPart[a].size();
           fWallprop = new double [ nshgLocalWallprop * nsdwp ];
 	    }
@@ -1785,7 +1786,9 @@ Partition_Problem( int  numProcs,
         }
 
 #if(VER_VARWALL == 1)
+
         if (nomodule.ivarwallprop != 0 && use_restart==1) {
+            
 			fprintf( rascii, "nshgLocalwallprop: %d\n", nshgLocalWallprop);
 			fprintf( rascii, "numVars: %d\n", nsdwp );
 			fprintf( rascii, "Step Number: %d\n", stepno);

--- a/Code/FlowSolvers/ThreeDSolver/svSolver/proces-varwall.f
+++ b/Code/FlowSolvers/ThreeDSolver/svSolver/proces-varwall.f
@@ -92,6 +92,7 @@ c      temporary local boundary element nodal coordinates and wall properties
        real*8, allocatable, dimension(:,:,:) :: xlb
        real*8, allocatable, dimension(:,:,:) :: wallpropl
        integer iblk,iel
+       integer nwallprop
 #endif
 c
 c.... shape function declarations
@@ -158,6 +159,9 @@ c
 
 #if(VER_VARWALL == 1)
 
+c....   variable thicknessvw, evw, ksvw, csvw, p0vw
+        nwallprop = 5
+
         if((ideformwall.eq.1) .and. (ivarwallprop.eq.1)) then
 
           do iblk = 1, nelblb
@@ -168,11 +172,11 @@ c
 
             npro   = lcblkb(1,iblk+1) - iel
 
-c            allocate ( xlb(npro,nenl,nsd) )
-            allocate ( wallpropl(npro,nshl,2) )
-
+c           allocate ( xlb(npro,nenl,nsd) )
+            allocate ( wallpropl(npro,nshl,nwallprop) )
+            
 c           get wall properties for each wall node for block iblk
-         call localx(wallpropg,wallpropl,  mienb(iblk)%p, 2, 'gather  ')
+            call localx(wallpropg,wallpropl,  mienb(iblk)%p, nwallprop, 'gather  ')
 
 c           get coordinates for wall nodes in block iblk
 c           call localx(point2x,  xlb,  mienb(iblk)%p,  nsd,  'gather  ')
@@ -185,6 +189,7 @@ c            deallocate(xlb)
 
           deallocate(wallpropg)
         end if
+
 #endif
 
 c.... close echo file
@@ -195,6 +200,7 @@ c
 c
 c.... call the semi-discrete predictor multi-corrector iterative driver
 c
+
         call itrdrv (y,              ac,
      &               uold,           point2x,
      &               iBC,            BC,

--- a/Code/FlowSolvers/ThreeDSolver/svSolver/readnblk-varwall.f
+++ b/Code/FlowSolvers/ThreeDSolver/svSolver/readnblk-varwall.f
@@ -319,20 +319,29 @@ c
           intfromfile = 0
           call readheader(igeom,fname1,intfromfile,itwo, 'double'//CHAR(0), iotype)     
 
-          if(intfromfile(1).gt.0) then
+          if (intfromfile(1).gt.0) then
               use_restart=0
               numnp=intfromfile(1)
               nwallprop=intfromfile(2)
 
-c.... Check that 5 nwallprop exist: thicknessvw, evw, ksvw, csvw, p0vw
-              if(nwallprop.ne.5) then
-                 warning ='WARNING: number of properties not equal 5'
-                 write(*,*) warning
-                 if(nwallprop.gt.6) then
-                   PRINT *,'ERROR: Variable Wall Properties Component Number greater than 6 in geombc.dat.proc'
-                   stop
-                 endif
+c.... Check that either 2 or 5 nwallprop exist: (thicknessvw, evw) with/without (ksvw, csvw, p0vw)
+              if (nwallprop.gt.6) then
+                  PRINT *,'ERROR: Variable Wall Properties Component Number greater than 6 in geombc.dat.proc'
+                  stop
               endif
+
+              if (itissuesuppt .eq. 1) then 
+                  if (nwallprop .ne. 5) then
+                      warning = 'WARNING: number of properties not equal 5'
+                      write(*,*) warning
+                  endif
+              else
+                  if (nwallprop .ne. 2) then
+                      warning = 'WARNING: number of properties not equal 2'
+                      write(*,*) warning
+                  endif
+              endif 
+              
 
               allocate( wallpropg(numnp, nwallprop) )
               

--- a/Code/FlowSolvers/ThreeDSolver/svSolver/readnblk-varwall.f
+++ b/Code/FlowSolvers/ThreeDSolver/svSolver/readnblk-varwall.f
@@ -85,6 +85,7 @@ C
 #if(VER_VARWALL == 1)
       character*255 fname0
       integer nwallprop
+
 #endif
       character*255 warning
 c     CAREFUL IGEOM,IBNDC,IRSTIN REDECLARED IN VARWALL
@@ -207,11 +208,13 @@ c
       call readheader(igeom,fname1,intfromfile,itwo, 'double'//CHAR(0), iotype)
       numnp=intfromfile(1)
 c      nsd=intfromfile(2)
+
       allocate( point2x(numnp,nsd) )
       allocate( xread(numnp,nsd) )
       ixsiz=numnp*nsd
       call readdatablock(igeom,fname1,xread,ixsiz, 'double'//CHAR(0),iotype)
       point2x = xread
+
 c
 c.... read the local to global node id mapping
 c
@@ -304,6 +307,7 @@ c
       call genbkb (ibksiz)
 
 #if(VER_VARWALL == 1)
+
 c.... read the values of wall property variables from geombc into wallpropg
 c
       if ((ideformwall.eq.1) .and. (ivarwallprop.eq.1)) then
@@ -313,26 +317,29 @@ c
           itwo=2
           fname1='varwallprop?'
           intfromfile = 0
-          call readheader(igeom,fname1,intfromfile,itwo, 'double'//CHAR(0), iotype)
+          call readheader(igeom,fname1,intfromfile,itwo, 'double'//CHAR(0), iotype)     
 
           if(intfromfile(1).gt.0) then
               use_restart=0
               numnp=intfromfile(1)
               nwallprop=intfromfile(2)
-              if(nwallprop.ne.2) then
-                 warning ='WARNING number of properties not equal 2'
+
+c.... Check that 5 nwallprop exist: thicknessvw, evw, ksvw, csvw, p0vw
+              if(nwallprop.ne.5) then
+                 warning ='WARNING: number of properties not equal 5'
                  write(*,*) warning
-                 if(nwallprop.gt.3) then
-                   PRINT *,'ERROR: Variable Wall Properties Component Number greater than 3 in geombc.dat.proc'
+                 if(nwallprop.gt.6) then
+                   PRINT *,'ERROR: Variable Wall Properties Component Number greater than 6 in geombc.dat.proc'
                    stop
                  endif
               endif
 
-              allocate( wallpropg(numnp,nwallprop) )
+              allocate( wallpropg(numnp, nwallprop) )
+              
               ixsiz=numnp*nwallprop
-              wallpropg = 0.0D0
-              call readdatablock(igeom,fname1,xread(:,1:nwallprop),ixsiz, 'double'//CHAR(0),iotype)
-              wallpropg = xread(:,1:nwallprop)
+              wallpropg = 0.0D0          
+
+              call readdatablock(igeom,fname1,wallpropg,ixsiz, 'double'//CHAR(0),iotype)
           endif
       endif
 #endif
@@ -430,6 +437,7 @@ c
        endif
 
 c
+
 #if(VER_VARWALL == 1)
 c.... read the values of wall property variables from restart into wallpropg
 c
@@ -452,13 +460,17 @@ c
         if (intfromfile(1).gt.0) then
            nshg2 = intfromfile(1)
            nwallprop = intfromfile(2)
+
 c          lstep=intfromfile(3) is not necessary since this is step 0
-c          not real lstep
-           if(nwallprop.ne.2) then
-             warning ='WARNING number of properties not equal 2'
+c          not real 
+
+
+c.... Check that 5 nwallprop exist: thicknessvw, evw, ksvw, csvw, p0vw
+           if(nwallprop.ne.5) then
+             warning ='WARNING: number of properties not equal 5'
              write(*,*) warning
-             if(nwallprop.gt.3) then
-               PRINT *,'ERROR: Variable Wall Properties Component Number greater than 3 in restart.0.proc'
+             if(nwallprop.gt.6) then
+               PRINT *,'ERROR: Variable Wall Properties Component Number greater than 6 in restart.0.proc'
                stop
              endif
            endif
@@ -483,14 +495,16 @@ c.... close c-binary files
 c
       call closefile( irstin, "read"//CHAR(0) )
       call closefile( igeom,  "read"//CHAR(0) )
-c
+
       deallocate(xread)
       deallocate(qread)
+
       if ( numpbc > 0 )  then
          deallocate(bcinpread)
          deallocate(ibctmpread)
       endif
       deallocate(iperread)
+
       if(numpe.gt.1)
      &     deallocate(ilworkread)
       deallocate(nbcread)

--- a/Code/FlowSolvers/ThreeDSolver/svSolver/solver_subroutines.f
+++ b/Code/FlowSolvers/ThreeDSolver/svSolver/solver_subroutines.f
@@ -4178,8 +4178,6 @@ c.... add the flux to the residual
 
         enddo
 
-
-
         if(ideformwall.eq.1) then
            rl(:,1,1) = rl(:,1,1) - rlKwall(:,1,1) 
            rl(:,1,2) = rl(:,1,2) - rlKwall(:,1,2)
@@ -4449,8 +4447,7 @@ C
       REAL*8                v3,          x1rot,       x2rot,      x3rot
 
 c     - ISL July 2019 - 
-      REAL*8                disp,        k_s,         c_s,        p_0
-      REAL*8                f_suppt_LHS
+      REAL*8                disp,        f_suppt_LHS
 C
 c
       dimension yl(npro,nshl,ndof),        rmu(npro),
@@ -5016,7 +5013,7 @@ c
 c.... NOTE:  the wall mass contributions should only have 3 nodal components 
 c.... since the fourth node is an interior node... therefore, the loops should
 c.... be done from 1 to nshlb=3...
-
+      
       do b = 1, nshlb
          do aa = 1, nshlb
 
@@ -5024,15 +5021,11 @@ c        The time term: tmp1=alpha_m*(1-lmp)*WdetJ*N^aN^b*rho*thickness
             tmp1 = tsFctvw * shpb(:,aa) * shpb(:,b)
 
 c...     ----------> External tissue support (ISL July 2019) <----------
-            k_s = 1D3
-            c_s = 1D4
-C             p_0 = 0D0
-            p_0 = -4D0 * 1.3332E3
 
             f_suppt_LHS = WdetJb * ( alfi * gami * Delt(itseq) * 
-     &                    c_s * shpb(:, aa) * shpb(:, b) + 
+     &                    csvw * shpb(:, aa) * shpb(:, b) + 
      &                    alfi * betai * Delt(itseq) * Delt(itseq) * 
-     &                    k_s * shpb(:, aa) * shpb(:, b) )
+     &                    ksvw * shpb(:, aa) * shpb(:, b) )
 c
             xKebe(:,1,aa,b) = xKebe(:,1,aa,b) + tmp1 + f_suppt_LHS
             xKebe(:,5,aa,b) = xKebe(:,5,aa,b) + tmp1 + f_suppt_LHS
@@ -5147,23 +5140,13 @@ c.... This is ugly, but I will fix it later...
       endif
 
 c.... ----------> External tissue support (ISL July 2019) <-------------
-      k_s = 1D3
-      c_s = 1D4
-C       p_0 = 0D0
-      p_0 = -4D0 * 1.3332E3
-
-C       print *, '(k_s, c_s, p_0)', k_s, c_s, p_0
-
-      f_suppt(:, 1) = -k_s * disp(:, 1) - c_s * u1 - p_0 * bnorm(:, 1)
-      f_suppt(:, 2) = -k_s * disp(:, 2) - c_s * u2 - p_0 * bnorm(:, 2)
-      f_suppt(:, 3) = -k_s * disp(:, 3) - c_s * u3 - p_0 * bnorm(:, 3)
+      f_suppt(:, 1) = -ksvw * disp(:, 1) - csvw * u1 - p0vw * bnorm(:, 1)
+      f_suppt(:, 2) = -ksvw * disp(:, 2) - csvw * u2 - p0vw * bnorm(:, 2)
+      f_suppt(:, 3) = -ksvw * disp(:, 3) - csvw * u3 - p0vw * bnorm(:, 3)
 
 
       endif                         ! end of deformable wall conditional
 
-
-
- 
       return
       end
       
@@ -11964,9 +11947,7 @@ c
 c
 c.... read in and block all data
 c
-
         call readnblk()
-
 c
 c.... open the echo file (echo closed at exit)
 c

--- a/svSolver_ExternalTissueSupport_README.txt
+++ b/svSolver_ExternalTissueSupport_README.txt
@@ -1,46 +1,63 @@
 ======================================================================================
 ---------------------------------------- README -------------------------------------
 ======================================================================================
-Ingrid Lan - ingridl@stanford.edu - July 2019
+Ingrid Lan - ingridl@stanford.edu - Sept. 2019
+
+External tissue support is implemented via Robin boundary conditions involving 
+springs, dampers, and external pressures on user-specified walls. 
 
 For the remainder of this document, thicknessvw, Evw, ksvw, csvw, and p0vw refer
 to the wall thickness, Young's modulus, spring constant, damping constant, and
-external pressure, respectively. External tissue support is implemented via Neumann
-traction boundary conditions involving springs, dampers, and external pressures on
-user-specified walls.
+external pressure, respectively. 
 
-References
+-------------------------------------- References --------------------------------------
 - Figueroa et al. (2006) - A coupled momentum method for modeling blood flow in
     three-dimensional deformable arteries. Comput Methods Appl Mech Engrg 195:5685-5706.
 - Moireau et al. (2012) - External tissue support and fluid-structure simulation
     in blood flows. Biomech Model Mechanobiol 11:1-18.
 
-1) UNIFORM WALL SIMULATION  - constant {thicknessvw, Evw, ksvw, csvw, p0vw}
+By default, External Tissue Support is OFF. Simulation files can be left unchanged if
+External Tissue Support is not desired. Otherwise, see below for how to enable
+External Tissue Support for uniform / variable wall simulations. 
 
+---------------------------------------- Notes ----------------------------------------
+(1) If thicknessvw and Evw are specified as uniform properties, then all tissue support
+    parameters (ksvw, csvw, and p0vw) must also be specified as uniform properties
+(2) If thicknessvw and Evw are specified as variable properties, then all tissue support
+    parameters must also be specified as variable properties.
+
+To summarize, when external tissue support is turned ON, all 5 wall properties must be
+of the same type -- either uniform or variable.
+
+
+1) UNIFORM WALL / EXTERNAL TISSUE SUPPORT ON - uniform {thicknessvw, Evw, ksvw, csvw, p0vw}
    - No changes to .cvpre/.svpre
 
    - Required additions to solver.inp (no default values provided)
+      - External Tissue Support: True
+      - Spring Constant of External Support: [ksvw value]
+      - Damping Constant of External Support: [csvw value]
+      - External Pressure: [p0vw value]
 
-      - Spring Constant of External Support: [value]
-      - Damping Constant of External Support: [value]
-      - External Pressure: [value]
+2) VARIABLE WALL / EXTERNAL TISSUE SUPPORT ON - variable {thicknessvw, Evw, ksvw, csvw, p0vw}
 
-2) VARIABLE WALL SIMULATION - variable {thicknessvw, Evw, ksvw, csvw, p0vw}
+   - Required additions to .cvpre/.svpre:
 
-   - Required additions to .cvpre/.svpre
-
-      - set_surface_ks_vtp [.vtp] [value]
+      - set_surface_ks_vtp [.vtp] [ksvw value]
       - ...
       - solve_varwall_ks
 
-      - set_surface_cs_vtp [.vtp] [value]
+      - set_surface_cs_vtp [.vtp] [csvw value]
       - ...
       - solve_varwall_cs
 
-      - set_surface_p0_vtp [.vtp] [value]
+      - set_surface_p0_vtp [.vtp] [p0vw value]
       - ...
       - solve_varwall_p0
 
-   - Required change to solver.inp
-      - Variable Wall Properties: True (instead of 'Variable Thickness and Young Mod')
+      **NOTE** If these are placed before 'varwallprop_write_vtp', the external tissue support
+               parameters will also be written to varwallprop.vtp.
+
+   - Required addition to solver.inp
+      - External Tissue Support: True
 

--- a/svSolver_ExternalTissueSupport_README.txt
+++ b/svSolver_ExternalTissueSupport_README.txt
@@ -1,0 +1,46 @@
+======================================================================================
+---------------------------------------- README -------------------------------------
+======================================================================================
+Ingrid Lan - ingridl@stanford.edu - July 2019
+
+For the remainder of this document, thicknessvw, Evw, ksvw, csvw, and p0vw refer
+to the wall thickness, Young's modulus, spring constant, damping constant, and
+external pressure, respectively. External tissue support is implemented via Neumann
+traction boundary conditions involving springs, dampers, and external pressures on
+user-specified walls.
+
+References
+- Figueroa et al. (2006) - A coupled momentum method for modeling blood flow in
+    three-dimensional deformable arteries. Comput Methods Appl Mech Engrg 195:5685-5706.
+- Moireau et al. (2012) - External tissue support and fluid-structure simulation
+    in blood flows. Biomech Model Mechanobiol 11:1-18.
+
+1) UNIFORM WALL SIMULATION  - constant {thicknessvw, Evw, ksvw, csvw, p0vw}
+
+   - No changes to .cvpre/.svpre
+
+   - Required additions to solver.inp (no default values provided)
+
+      - Spring Constant of External Support: [value]
+      - Damping Constant of External Support: [value]
+      - External Pressure: [value]
+
+2) VARIABLE WALL SIMULATION - variable {thicknessvw, Evw, ksvw, csvw, p0vw}
+
+   - Required additions to .cvpre/.svpre
+
+      - set_surface_ks_vtp [.vtp] [value]
+      - ...
+      - solve_varwall_ks
+
+      - set_surface_cs_vtp [.vtp] [value]
+      - ...
+      - solve_varwall_cs
+
+      - set_surface_p0_vtp [.vtp] [value]
+      - ...
+      - solve_varwall_p0
+
+   - Required change to solver.inp
+      - Variable Wall Properties: True (instead of 'Variable Thickness and Young Mod')
+


### PR DESCRIPTION
Changes were made to svPre, svSolver, and svPost for external tissue support implementation. Non-physiological oscillations can now be very effectively dampened out.

External tissue support can be turned on / off as a flag in solver.inp. Since it is off by default, the revised source code will still be compatible with old simulation files.

The spring constant, damping constant, and external pressure can be assigned as uniform or variable wall properties (similar to wall thickness and Young's modulus). If the wall thickness (h) and Young's modulus (E) are specified as uniform properties, then all three tissue support properties must also be specified as uniform properties; if h and E are specified as variable properties, then all tissue support properties must also be specified as variable properties. This was a conscious design choice since svSolver calls distinct functions for uniform vs. variable wall simulations.

If variable, these properties can be written out to varwallprop.vtp (in svPre) and all post-processed vtp's & vtu's (in svPost) along with h and E.

I have written up a README (svSolver_ExternalTissueSupport_README.txt) documenting the necessary changes to .svpre/.cvpre and solver.inp to turn on external tissue support.

Weiguang and I have both tested the four different test cases (uniform vs. variable; tissue support on vs. off). I would be happy to share these simulation files. I also kept a detailed outline of my changes to various files, which I could also share.