### PR TITLE
Broken vtk download link issue 64

### DIFF
--- a/Code/CMake/SimVascularMacros.cmake
+++ b/Code/CMake/SimVascularMacros.cmake
@@ -726,7 +726,7 @@ macro(sv_externals_check_versioning check_file_contents platform_version compile
   else()
     # The worst! fatal error
     message(WARNING "${GENERIC_MESSAGE} Pre-built binaries for ${SV_PLATFORM_DIR} version ${nothing_oldest_platform_ver} and compiler ${nothing_oldest_compiler}/${nothing_oldest_compiler_ver}")
-    set(${output_dir} "${nothing_oldest_platform_ver}/${nothing_oldest_compiler}-${nothing_oldest_compiler_ver}/${nothing_rest_of_line}")
+    set(${output_dir} "${nothing_oldest_platform_ver}/${nothing_oldest_compiler}/${nothing_oldest_compiler_ver}/${nothing_rest_of_line}")
   endif()
 
 endmacro()

--- a/Code/CMake/SimVascularMacros.cmake
+++ b/Code/CMake/SimVascularMacros.cmake
@@ -606,7 +606,16 @@ endmacro()
 #-----------------------------------------------------------------------------
 
 #-----------------------------------------------------------------------------
+
+#-------------------------------
 # sv_externals_check_versioning
+#-------------------------------
+# This macro tries to match the build host platform, compiler and compiler version against
+# those listed in the externals externals_compiler_info.txt file to determine the best
+# externals version to use.
+#
+# The 'output_dir' variable is used as part of the externals download url.
+#
 macro(sv_externals_check_versioning check_file_contents platform_version compiler compiler_version output_dir)
 
   # Initiate loop variables


### PR DESCRIPTION
Fixes the svSolver CMake macro sv_externals_check_versioning() which sets part of the external download url. The code setting the url for unknown Intel compiler was using a dash rather than a slash for the url.