### PR TITLE
More robust restart

### DIFF
--- a/Code/FlowSolvers/ThreeDSolver/svSolver/coronary_subroutines.f
+++ b/Code/FlowSolvers/ThreeDSolver/svSolver/coronary_subroutines.f
@@ -57,6 +57,8 @@ c ================================
       include "common_blocks/nomodule.h"
       include "common_blocks/inpdat.h"
       INTEGER k,j,n
+      logical flag1, flag2, flag3
+      character*50 fname1, fname2, fname3
 c      print *,'I am in the initCORt subroutine'
       open(unit=815, file='cort.dat',status='old')
 c         read (815,*)
@@ -124,12 +126,33 @@ c	       print *, 'allocation of conv coef and q and phist done'
          PlvHistCOR = zero
          PHistCOR = zero
 c	       print *, 'allocation of conv coef and q and phist done'
-         call ReadDataFile(QHistCOR(1:lstep+1,:),lstep+1,numCORSrfs,
-     &      'QHistCOR.dat',876)
-         call ReadDataFile(PHistCOR(1:lstep+1,:),lstep+1,numCORSrfs,
-     &      'PHistCOR.dat',877)
-         call ReadDataFile(PlvHistCOR(1:lstep+1,:),lstep+1,numCORSrfs,
-     &      'PlvHistCOR.dat',879)
+c     check if *HistCOR.dat.step# exists
+         write (fname1, "(a13,I0)") "QHistCOR.dat.", lstep
+         fname1 = trim(fname1)
+         write (fname2, "(a13,i0)") "PHistCOR.dat.", lstep
+         fname2 = trim(fname2)
+         write (fname3, "(a15,i0)") "PlvHistCOR.dat.", lstep
+         fname3 = trim(fname3)
+         inquire(FILE=fname1, EXIST=flag1)
+         inquire(FILE=fname2, EXIST=flag2)
+         inquire(FILE=fname3, EXIST=flag3)
+         if (flag1.AND.flag2.AND.flag3) then
+c     read the results in format *HistCOR.dat.step#
+            call ReadDataFile(QHistCOR(1:lstep+1,:),lstep+1,numCORSrfs,
+     &         fname1,876)
+            call ReadDataFile(PHistCOR(1:lstep+1,:),lstep+1,numCORSrfs,
+     &         fname2,877)
+            call ReadDataFile(PlvHistCOR(1:lstep+1,:),lstep+1,numCORSrfs,
+     &         fname3,879)
+         else
+c     read the results in legacy format *HistCOR.dat
+            call ReadDataFile(QHistCOR(1:lstep+1,:),lstep+1,numCORSrfs,
+     &         'QHistCOR.dat',876)
+            call ReadDataFile(PHistCOR(1:lstep+1,:),lstep+1,numCORSrfs,
+     &         'PHistCOR.dat',877)
+            call ReadDataFile(PlvHistCOR(1:lstep+1,:),lstep+1,numCORSrfs,
+     &         'PlvHistCOR.dat',879)
+         endif
       endif
 c     print*, 'End of initcort subroutine'      
       return
@@ -525,6 +548,7 @@ c
       real*8    timestepCOR, PlvistNext(0:MAXSURF)
       real*8    y(nshg,4)
       real*8    CoupleArea(0:MAXSURF), POnly(nshg)
+      character*50 fname
       
       PlvistNext=zero      
       call CORint(timestepCOR*stepn,PlvistNext)
@@ -536,12 +560,18 @@ c
 
       if ((mod(lstep, ntout) .eq. 0).and.
      &   (myrank .eq. zero)) then
+         write (fname, "(a13,i0)") "QHistCOR.dat.", lstep
+         fname = trim(fname)
          call OutputDataFile(QHistCOR(1:lstep+1,:),lstep+1,numSrfs,
-     &      'QHistCOR.dat',876)
+     &      fname,876)
+         write (fname, "(a13,i0)") "PHistCOR.dat.", lstep
+         fname = trim(fname)
          call OutputDataFile(PHistCOR(1:lstep+1,:),lstep+1,numSrfs,
-     &      'PHistCOR.dat',877)
+     &      fname,877)
+         write (fname, "(a15,i0)") "PlvHistCOR.dat.", lstep
+         fname = trim(fname)
          call OutputDataFile(PlvHistCOR(1:lstep+1,:),lstep+1,numSrfs,
-     &      'PlvHistCOR.dat',879)
+     &      fname,879)
       endif 
 
       return

--- a/Code/FlowSolvers/ThreeDSolver/svSolver/itrdrv-closedloop-varwall-coronary.f
+++ b/Code/FlowSolvers/ThreeDSolver/svSolver/itrdrv-closedloop-varwall-coronary.f
@@ -908,7 +908,8 @@ c
      &                      BC,        iper)
            endif
 
-
+c     increment time step after all outputs have been written
+      call writeNumStart ()
 
 c....  print out results.
 c
@@ -1027,6 +1028,9 @@ c
             call append_restart(myrank, lstep, nshg, 1,
      &                     yerror(:,4),'pressure error'//CHAR(0))
           endif
+
+c     increment time step after all outputs have been written
+         call writeNumStart ()
 
       endif
 

--- a/Code/FlowSolvers/ThreeDSolver/svSolver/solver_subroutines.f
+++ b/Code/FlowSolvers/ThreeDSolver/svSolver/solver_subroutines.f
@@ -13798,7 +13798,6 @@ C
         character*8 mach2
         character*20 fname1,  fmt1
         character*5  cname
-        integer ioerr
 
 c
         dimension q(nshg,ndof),ac(nshg,ndof)
@@ -13843,15 +13842,6 @@ c
            call write_restart(myrank, lstep, nshg, ndof, 
      &          qold, acold)
 
-          if (myrank.eq.master) then 
-            open(unit=72,file='numstart.dat',status='old',iostat=ioerr)
-            if (ioerr.eq.0) then
-              write(72,*) lstep
-            else
-              write(*,*) 'IO_ERROR file: numstart.dat code: ',ioerr
-            endif
-            close(72)
-          endif
            deallocate(qold)
            deallocate(acold)
            return
@@ -13871,6 +13861,31 @@ c
 c.... end
 c
         end
+
+c     This subroutine writes the current time step to file. It is called
+c     after all update/output functions have been called. If writing to
+c     file is interrupted in any of these functions, the simulation can
+c     be restarted from the previous time step.
+
+      subroutine writeNumStart ()
+
+      include "common_blocks/timdat.h"
+
+      integer ioerr
+
+      if (myrank.eq.master) then
+         open(unit=72,file='numstart.dat',status='old',iostat=ioerr)
+
+         if (ioerr.eq.0) then
+            write(72,*) lstep
+         else
+            write(*,*) 'IO_ERROR file: numstart.dat code: ',ioerr
+         endif
+
+         close(72)
+      endif
+      end
+
 
 !> This subroutine is responsible for rotating 
 !! the residual and solution vectors for axisymmetric BC's.


### PR DESCRIPTION
Fixes #80 for reals. This introduces two changes:

1) Write coronary BC files in every time step (analog to RCR BC in #81). This can also restart from simulation output generated from previous svSolver versions, where only legacy `QHistCOR.dat`, `PHistCOR.dat`, `PlvHistCOR.dat` are present.
```
PHistCOR.dat.1
PHistCOR.dat.2
...
QHistCOR.dat.1
QHistCOR.dat.2
...
PlvHistCOR.dat.1
PlvHistCOR.dat.2
...
```
2) Increment time step on disk only after **all** output is written to file. I created a new subroutine `writeNumStart` to only write `numstart.dat`. This subroutine is called twice in `itrdrv-closedloop-varwall-coronary.f`, following each call to `restar ('out ',  ...)`  **after** all functions that write to disk. In case the simulation is terminated while writing to disk, the `numstart.dat` still points to the previous time step on disk.

