### PR TITLE
Update post_solver.cxx

### DIFF
--- a/Code/FlowSolvers/ThreeDSolver/svPost/post_solver.cxx
+++ b/Code/FlowSolvers/ThreeDSolver/svPost/post_solver.cxx
@@ -2101,6 +2101,9 @@ int main(int argc, char* argv[])
         }
         else if(tmpstr=="-calcws"){
             RequestedCalcWS = true;
+            RequestedvInPlaneTraction=true;
+            RequestedvWSS = true;
+            RequestedSolution = true;
         }
         else if(tmpstr=="-applywd"){
             RequestedApplyWD = true;


### PR DESCRIPTION
It has been reported that segmentation errors can occur when reducing field data (e.g. wall shear stress) from restart files likely due to a corrupted header in a restart file. One may need to recalculate wall shear stress from solutions (velocity).  The proposed change in post_solver.cxx is to output solutions and recalauted WSS/tractions only when other field data cause segmentation errors in svpost.