### PR TITLE
Remove problem not finding MPI_EXTRA_LIBRARY and setting no-mpi build…

### DIFF
--- a/Code/CMake/FindMPI.cmake
+++ b/Code/CMake/FindMPI.cmake
@@ -625,6 +625,7 @@ if (MPI_NUMLIBS GREATER 1)
   set(MPI_EXTRA_LIBRARY ${MPI_EXTRA_LIBRARY_WORK} CACHE STRING "Extra MPI libraries to link against" FORCE)
 else()
   set(MPI_EXTRA_LIBRARY "MPI_EXTRA_LIBRARY-NOTFOUND" CACHE STRING "Extra MPI libraries to link against" FORCE)
+  set(MPI_EXTRA_LIBRARY "")
 endif()
 #=============================================================================
 

--- a/Code/FlowSolvers/ThreeDSolver/CMakeLists.txt
+++ b/Code/FlowSolvers/ThreeDSolver/CMakeLists.txt
@@ -113,6 +113,8 @@ if(NOT SV_USE_DUMMY_MPI)
   if(SV_BUILD_ADDITIONAL_NOMPI_VERSION)
     set(SV_USE_DUMMY_MPI ON)
     set(SV_MPI_NAME_EXT "-nompi")
+    # Set including the mpi.h from dummyMPI.
+    include_directories(BEFORE ${CMAKE_CURRENT_SOURCE_DIR}/dummyMPI)
     add_subdirectory(dummyMPI)
     add_subdirectory(svLS svLS${SV_MPI_NAME_EXT})
     add_subdirectory(svSolver svSolver${SV_MPI_NAME_EXT})


### PR DESCRIPTION
… to include dummyMPI/mpi.h.

This now works for both OpenMPI and MPICH on MacOS and Ubuntu.